### PR TITLE
Add bounds checks for height matrices to genreateTerrainNoise()

### DIFF
--- a/common/src/main/java/com/pg85/otg/generator/ChunkProviderOTG.java
+++ b/common/src/main/java/com/pg85/otg/generator/ChunkProviderOTG.java
@@ -425,9 +425,9 @@ public class ChunkProviderOTG
                     }
                     if (this.riverFound)
                     {
-                        output += biomeConfig.riverHeightMatrix[y];
+                        output += biomeConfig.riverHeightMatrix[Math.min(biomeConfig.riverHeightMatrix.length - 1, y)];
                     } else {
-                        output += biomeConfig.heightMatrix[y];
+                        output += biomeConfig.heightMatrix[Math.min(biomeConfig.heightMatrix.length - 1, y)];
                     }
 
                     this.rawTerrain[i3D] = output;


### PR DESCRIPTION
This fixes an ArrayIndexOutOfBoundsException I keep running into when trying to generate certain worlds.