### PR TITLE
Fix NullPointerException on TabComplet

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/events/OTGCommandHandler.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/events/OTGCommandHandler.java
@@ -361,7 +361,7 @@ public final class OTGCommandHandler implements ICommand
 		    		        	msg += VALUE_COLOR + " (" + enumcreaturetype.name() + ")";
 		    		        }
 		    		    }
-		        		OTG.log(LogMarker.INFO, msg.replace("ง2", "").replace("ง", "").replace("งa", ""));
+		        		OTG.log(LogMarker.INFO, msg.replace("ยง2", "").replace("ยง", "").replace("ยงa", ""));
 		        		sender.sendMessage(new TextComponentString(MESSAGE_COLOR + "- " + msg));
     		        } else {
     		        	// This can happen for LIGHTNING_BOLT since it appears to be added to the
@@ -752,9 +752,27 @@ public final class OTGCommandHandler implements ICommand
 	}
 
 	@Override
-	public List<String> getTabCompletions(MinecraftServer server,
-			ICommandSender sender, String[] args, BlockPos targetPos) {
-		return null;
+	public List<String> getTabCompletions(MinecraftServer server,ICommandSender sender, String[] args, BlockPos targetPos) {
+		
+		List<String> listComplet = new ArrayList<String>();
+		
+		listComplet.add("worldinfo");
+		listComplet.add("biome");
+		listComplet.add("bo3");
+		listComplet.add("tp");
+		
+		listComplet.add("pregenerator");
+		listComplet.add("pregen");
+		
+		listComplet.add("dimension");
+		listComplet.add("dim");
+		
+		listComplet.add("blocks");
+		listComplet.add("entities");
+		listComplet.add("unloadbo3s");
+		listComplet.add("GetModData");
+		
+		return listComplet;
 	}
 
 	@Override


### PR DESCRIPTION
Hello, to begin, I'm very sorry for my bad english.

In version 1.12 v6, you have an NullPointerException when you want to auto complet your sub command after "otg".

`[22:04:16] [Server console handler/ERROR] [net.minecraftforge.server.console.ConsoleCommandCompleter]: Failed to tab complete
java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[?:1.8.0_181]
	at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[?:1.8.0_181]
	at net.minecraftforge.server.console.ConsoleCommandCompleter.complete(ConsoleCommandCompleter.java:67) ~[forge-1.12.2-14.23.5.2768-universal.jar:?]
	at org.jline.reader.impl.LineReaderImpl.doComplete(LineReaderImpl.java:3765) ~[jline-3.5.1.jar:?]
	at org.jline.reader.impl.LineReaderImpl.expandOrComplete(LineReaderImpl.java:3684) ~[jline-3.5.1.jar:?]
	at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:552) [jline-3.5.1.jar:?]
	at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:390) [jline-3.5.1.jar:?]
	at net.minecraftforge.server.console.TerminalHandler.handleCommands(TerminalHandler.java:61) [TerminalHandler.class:?]
	at net.minecraft.server.dedicated.DedicatedServer$2.run(DedicatedServer.java:99) [nz$2.class:?]
Caused by: java.lang.NullPointerException
	at net.minecraft.server.MinecraftServer.func_184104_a(MinecraftServer.java:922) ~[MinecraftServer.class:?]
	at net.minecraftforge.server.console.ConsoleCommandCompleter.lambda$complete$0(ConsoleCommandCompleter.java:63) ~[ConsoleCommandCompleter.class:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_181]
	at net.minecraft.util.Util.func_181617_a(SourceFile:46) ~[h.class:?]
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:723) ~[MinecraftServer.class:?]
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397) ~[nz.class:?]
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668) ~[MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526) ~[MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]`

I fix that with returning an List of String with inside, the different sub-commands (pregen / blocks & ...)