### PR TITLE
Use WorldInfo.setAllowCommands instead of calling WorldSettings.enableCommands

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/OTGWorldType.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/OTGWorldType.java
@@ -65,11 +65,8 @@ public class OTGWorldType extends WorldType
 
         WorldSettings worldSettings = new WorldSettings(mcWorld.getWorldInfo().getSeed(), mcWorld.getWorldInfo().getGameType(), mcWorld.getWorldInfo().isMapFeaturesEnabled(), mcWorld.getWorldInfo().isHardcoreModeEnabled(), mcWorld.getWorldInfo().getTerrainType());
         worldSettings.setGeneratorOptions("OpenTerrainGenerator");
-        if(mcWorld.getWorldInfo().areCommandsAllowed())
-        {
-        	worldSettings.enableCommands();
-        }
         mcWorld.getWorldInfo().populateFromWorldSettings(worldSettings);
+        mcWorld.getWorldInfo().setAllowCommands(mcWorld.getWorldInfo().areCommandsAllowed());
 
         ForgeWorld world = this.worldLoader.getOrCreateForgeWorld(mcWorld);
         if (world == null)


### PR DESCRIPTION
WorldSettings.enableCommands is a client-only method, so an exception
will be thrown if it is called from the dedicated server