### PR TITLE
[Duplicate] fix: dimensions GUI -> crash on server without forge mod installed

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/events/client/KeyBoardEventListener.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/events/client/KeyBoardEventListener.java
@@ -1,5 +1,6 @@
 package com.pg85.otg.forge.events.client;
 
+import com.pg85.otg.OTG;
 import com.pg85.otg.forge.dimensions.OTGDimensionManager;
 import com.pg85.otg.forge.dimensions.OTGWorldProvider;
 import com.pg85.otg.forge.gui.OTGGuiDimensionList;
@@ -32,10 +33,15 @@ public class KeyBoardEventListener
 			}
 			if (ClientProxy.otgInGameUIKeyBinding.isPressed())
 			{
-				// Only open the menu for overworld or OTG dimensions
 		    	if(
-					Minecraft.getMinecraft().world != null && 
-					Minecraft.getMinecraft().world.provider != null && 
+					// The GUI screen requires the dimensions configuration to be available, so it shouldn't be opened
+					// with an unset configuration.
+                    // This is the case when connecting to servers without the mod installed, for example.
+					OTG.GetDimensionsConfig() != null &&
+
+					// Only open the menu for overworld or OTG dimensions
+					Minecraft.getMinecraft().world != null &&
+					Minecraft.getMinecraft().world.provider != null &&
 					(
     					Minecraft.getMinecraft().world.provider.getDimension() == 0 ||
     					Minecraft.getMinecraft().world.provider instanceof OTGWorldProvider
@@ -44,7 +50,7 @@ public class KeyBoardEventListener
 	        	{
 	        		Minecraft.getMinecraft().displayGuiScreen(new OTGGuiDimensionList(null));
 	        	}
-			}				
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Closed in favor of https://github.com/PG85/OpenTerrainGenerator/pull/245**

I recreated my forked repository, by which I accidentally broke the link to the original branch in this PR. In order to avoid problems when merging, I created a [new pull request](https://github.com/PG85/OpenTerrainGenerator/pull/245).

---

When the dimensions GUI was opened (default keybind: o) while being connected to a server without the forge version of this mod installed, the game would previously have crashed.

My suggested fix is simply to only open the dimensions-GUI when the player is connected to a server that provides the necessary information for it.