### PR TITLE
fix: bump protocol version

### DIFF
--- a/common/src/main/java/com/pg85/otg/configuration/standard/PluginStandardValues.java
+++ b/common/src/main/java/com/pg85/otg/configuration/standard/PluginStandardValues.java
@@ -18,7 +18,7 @@ public class PluginStandardValues extends Settings
     
     // Network
     public static final String ChannelName = "OpenTerrainGenerator";
-    public static final int ProtocolVersion = 5;
+    public static final int ProtocolVersion = 6;
     
     // Plugin Defaults
     public static final Setting<LogLevels> LogLevel = enumSetting("LogLevel", LogLevels.Standard);


### PR DESCRIPTION
When a client with OTG v6 connected to a server running v7, the client
connection had previously crashed.

The protocol version was increased to fix this.