### PR TITLE
Fixed teleporting to the Nether not working in some cases

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/events/dimensions/EntityTravelToDimensionListener.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/events/dimensions/EntityTravelToDimensionListener.java
@@ -26,16 +26,9 @@ public class EntityTravelToDimensionListener
 	@SubscribeEvent
 	public void entityTravelToDimension(EntityTravelToDimensionEvent e)
 	{
-		if(e.getDimension() == -1)
+		// Make sure the player is above a portal block so we can check if this is a Quartz portal
+		if(e.getDimension() == -1 && ForgeMaterialData.ofMinecraftBlockState(e.getEntity().getEntityWorld().getBlockState(e.getEntity().getPosition())).toDefaultMaterial().equals(DefaultMaterial.PORTAL))
 		{
-			// Make sure the player is above a portal block so we can check if this is a Quartz portal
-			if(!ForgeMaterialData.ofMinecraftBlockState(e.getEntity().getEntityWorld().getBlockState(e.getEntity().getPosition())).toDefaultMaterial().equals(DefaultMaterial.PORTAL))
-			{
-				e.getEntity().timeUntilPortal = 0;
-				e.setCanceled(true);
-				return;
-			}
-
 			Entity sender = e.getEntity();
 			BlockPos playerPos = new BlockPos(sender.getPosition());
 			World world = sender.getEntityWorld();


### PR DESCRIPTION
We talked a little about this bug on Discord. The event handler currently cancels anything going to the Nether that didn't involve a portal, when it should just ignore it instead.