### PR TITLE
fixed saves path bug in non-Windows forge environments

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gui/dimensions/OTGGuiDimensionList.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gui/dimensions/OTGGuiDimensionList.java
@@ -637,7 +637,7 @@ public class OTGGuiDimensionList extends GuiScreen implements GuiYesNoCallback
 			// Don't overwrite existing worlds, UI shouldn't allow it anyway
             if (this.mc.getSaveLoader().getWorldInfo(worldName) == null)
             {    				
-        		DimensionsConfig forgeWorldConfig = new DimensionsConfig(new File(this.mc.gameDir.getAbsolutePath() + "\\saves\\"), this.worldName);
+        		DimensionsConfig forgeWorldConfig = new DimensionsConfig(new File(this.mc.gameDir.getAbsolutePath(), "saves"), this.worldName);
         		forgeWorldConfig.WorldName = this.worldName;
         		forgeWorldConfig.Overworld = this.dimensions.get(0).clone();
         		forgeWorldConfig.Dimensions = new ArrayList<DimensionConfig>();


### PR DESCRIPTION
Noticed in Linux (and probably OSX) OTG creates a ".minecraft\saves\" directory instead of creating a "saves" subdirectory of ".minecraft" due to hard-coded "\\" path separator.