### PR TITLE
ContinueNormal - replace fillbiome with normal generation

### DIFF
--- a/common/src/main/java/com/pg85/otg/generator/biome/layers/LayerFromImage.java
+++ b/common/src/main/java/com/pg85/otg/generator/biome/layers/LayerFromImage.java
@@ -9,6 +9,7 @@ import com.pg85.otg.logging.LogMarker;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import javax.imageio.ImageIO;
 
@@ -90,12 +91,16 @@ public class LayerFromImage extends Layer
                 if (config.biomeColorMap.containsKey(color))
                     this.biomeMap[nColor] = config.biomeColorMap.get(color);
                 else
-                    this.biomeMap[nColor] = fillBiome;
+                    // ContinueNormal interprets a -1 as "Use the childLayer"
+                    if (this.imageMode == WorldConfig.ImageMode.ContinueNormal)
+                        this.biomeMap[nColor] = -1;
+                    else
+                        this.biomeMap[nColor] = fillBiome;
             }
         }
         catch (IOException ioexception)
         {
-            OTG.log(LogMarker.FATAL, ioexception.getStackTrace().toString());
+            OTG.log(LogMarker.FATAL, Arrays.toString(ioexception.getStackTrace()));
         }
     }
 
@@ -150,14 +155,27 @@ public class LayerFromImage extends Layer
                     {
                         int Buffer_x = x + xi - xOffset;
                         int Buffer_z = z + zi - zOffset;
+                        // if X or Z is outside map bounds
                         if (Buffer_x < 0 || Buffer_x >= this.mapWidth || Buffer_z < 0 || Buffer_z >= this.mapHeight)
                         {
                             if (childBiomes != null)
                                 resultBiomes[(xi + zi * xSize)] = childBiomes[(xi + zi * xSize)];
                             else
                                 resultBiomes[(xi + zi * xSize)] = this.fillBiome;
-                        } else
-                            resultBiomes[(xi + zi * xSize)] = this.biomeMap[Buffer_x + Buffer_z * this.mapWidth];
+                        }
+                        else
+                        {
+                            int biome_id_buffer = this.biomeMap[Buffer_x + Buffer_z * this.mapWidth];
+                            // If set to -1 in the constructor above, uses the childlayer instead of the fillbiome if it exists.
+                            if (biome_id_buffer == -1)
+                            {
+                                if (childBiomes != null)
+                                    biome_id_buffer = childBiomes[(xi + zi * xSize)];
+                                else
+                                    biome_id_buffer = this.fillBiome;
+                            }
+                            resultBiomes[(xi + zi * xSize)] = biome_id_buffer;
+                        }
                     }
                 break;
             case FillEmpty:


### PR DESCRIPTION
Instead of using just a single fillBiome, ContinueNormal now inserts normal generation into holes in a fromImage map.

The -1 value in the biomeMap is only assigned and only looked for in ContinueNormal mode. The -1 value is used because it doesn't interfere with the biome ID's. I originally tried using the ID of the fillBiome, but that made the fillBiome not spawn when painted in. It feels a bit like a bodge, but I couldn't think of a smarter way to do it, and I also haven't found any possible side effects from it.

I've been testing this with a modified Vanilla Vistas running in FromImage mode, and I haven't found any issues. It's a bit quirky to use because you can't predict what biomes will spawn, but it's definitely possible to get used to.