### PR TITLE
Improve edge biome generation

### DIFF
--- a/common/src/main/java/com/pg85/otg/generator/biome/layers/LayerBiomeBorder.java
+++ b/common/src/main/java/com/pg85/otg/generator/biome/layers/LayerBiomeBorder.java
@@ -51,6 +51,7 @@ public class LayerBiomeBorder extends Layer
                 biomeId = getBiomeFromLayer(selection);
                 if (bordersFrom[biomeId] != null)
                 {
+                    // check in a plus formation to see if the tile is suitable for an edge biome
                     northCheck = getBiomeFromLayer(childInts[(xi + 1 + (zi) * (xSize + 2))]);
                     southCheck = getBiomeFromLayer(childInts[(xi + 1 + (zi + 2) * (xSize + 2))]);
                     eastCheck = getBiomeFromLayer(childInts[(xi + 2 + (zi + 1) * (xSize + 2))]);
@@ -61,7 +62,25 @@ public class LayerBiomeBorder extends Layer
                     {
                         if ((northCheck != biomeId) || (eastCheck != biomeId) || (westCheck != biomeId) || (southCheck != biomeId))
                         {
+                            // if it is suitable, set the edge biome
                             selection = (selection & (IslandBit | RiverBits | IceBit)) | LandBit | bordersTo[biomeId] | BiomeBitsAreSetBit;
+                        }
+                        else
+                        {
+                            // if it's not suitable, try again but sample in an X formation to make sure we didn't miss any potential edge
+                            int nwCheck = getBiomeFromLayer(childInts[(xi + 0 + (zi) * (xSize + 2))]);
+                            int neCheck = getBiomeFromLayer(childInts[(xi + 2 + (zi) * (xSize + 2))]);
+                            int swCheck = getBiomeFromLayer(childInts[(xi + 0 + (zi + 2) * (xSize + 2))]);
+                            int seCheck = getBiomeFromLayer(childInts[(xi + 2 + (zi + 2) * (xSize + 2))]);
+                            if (biomeFrom[nwCheck] && biomeFrom[neCheck] && biomeFrom[swCheck] && biomeFrom[seCheck])
+                            {
+                                if ((nwCheck != biomeId) || (neCheck != biomeId) || (swCheck != biomeId) || (seCheck != biomeId))
+                                {
+                                    // if the second test is suitable, set the edge biome
+                                    selection = (selection & (IslandBit | RiverBits | IceBit)) | LandBit | bordersTo[biomeId] | BiomeBitsAreSetBit;
+                                }
+                                // if the selection isn't suitable at this point, we can be almost certain that it's not an edge
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #449 

This PR fixes edge biome generation by adding an additional check to edge biome detection.
First, the biomes are sampled in a plus formation like before. This PR introduces an additional check that samples biomes in an X formation to see test for edge biomes again.

Caveats: The edges are now 2x bigger than before due to the additional check. This means biomes' `BiomeSizeWhenBorder` property needs to be increased by 1 to offset for this change.

Before the change:
![](https://cdn.discordapp.com/attachments/645446523672461312/692543454433247303/unknown.png)

After the change:
![](https://cdn.discordapp.com/attachments/645446523672461312/692543525975490600/unknown.png)
Notice the larger borders. Presets need to increase the `BiomeSizeWhenBorder` property by 1 to fix that.

After increasing ``BiomeSizeWhenBorder`:
![](https://cdn.discordapp.com/attachments/645446523672461312/692768419501834271/unknown.png)
This is basically the same as the original, but fixed!

Unfortunately, this will break presets in 1.12. I'm opening this PR to act as a reference implementation for the fix to go in 1.15. People who want the fix in 1.12 can build my fork of OTG.