### PR TITLE
Fix biome groups

### DIFF
--- a/common/src/main/java/com/pg85/otg/generator/biome/layers/Layer.java
+++ b/common/src/main/java/com/pg85/otg/generator/biome/layers/Layer.java
@@ -70,11 +70,6 @@ public abstract class Layer
      */
     protected Layer child;
 
-    /**
-     * This helps our random numbers be a little more random
-     */
-    protected static final int Entropy = 10000;
-
     /*
      * LayerIsland - chance to big land
      * LayerLandRandom - a(3) - chance to increase big land
@@ -202,8 +197,11 @@ public abstract class Layer
         return i;
     }
 
-    protected int nextGroupInt(int x)
+    //TODO: improve this LCG somehow? currently it works, but just barely
+    protected int nextGroupInt(long worldSeed, int x)
     {
+        this.scrambledGroupSeed ^= worldSeed; // do a simple xor with the world seed as a randomization
+
         int i = (int) ((this.scrambledGroupSeed >> 24) % x);
         if (i < 0)
         {

--- a/common/src/main/java/com/pg85/otg/generator/biome/layers/LayerBiomeGroups.java
+++ b/common/src/main/java/com/pg85/otg/generator/biome/layers/LayerBiomeGroups.java
@@ -41,19 +41,18 @@ public class LayerBiomeGroups extends Layer
 
                 if ((currentPiece & LandBit) != 0 && (currentPiece & BiomeGroupBits) == 0) // land without biome group
                 {
-                	// TODO: even with rarity 1 this always spawns the biome
-
                     possibleGroups = biomeGroupManager.getGroupDepthMap(depth);
-                    newGroupRarity = nextGroupInt(BiomeGroupManager.getMaxRarityFromPossibles(possibleGroups)*Entropy);
-                        //>>	Spawn the biome based on the rarity spectrum
+
+                    newGroupRarity = nextGroupInt(world.getSeed(), BiomeGroupManager.getMaxRarityFromPossibles(possibleGroups));
+                        // Spawn the biome based on the rarity spectrum
                         for (Entry<Integer, BiomeGroup> group : possibleGroups.entrySet())
                         {
-                            if (newGroupRarity/Entropy < group.getKey())
+                            if (newGroupRarity < group.getKey())
                             {
                                 if (group.getValue() != null)
                                 {
                                     currentPiece |= (group.getValue().getGroupId() << BiomeGroupShift) |
-                                    //>>	If the average temp of the group is cold
+                                    // If the average temp of the group is cold
                                     ((group.getValue().isColdGroup() && freezeGroups) ? IceBit : 0);
                                 }
                                 break;


### PR DESCRIPTION
Fixes #424 

This PR fixes biome groups being the same in every world and always generating the first group at 0,0 by introducing a simple xor with the world seed into the existing biome group LCG.

It shouldn't break any presets or worlds, and I don't think any of the major presets use normal group mode anyway :P