### PR TITLE
Fixes to BO3 spawning

### DIFF
--- a/common/src/main/java/com/pg85/otg/customobjects/bo3/BO3.java
+++ b/common/src/main/java/com/pg85/otg/customobjects/bo3/BO3.java
@@ -103,12 +103,6 @@ public class BO3 implements StructuredCustomObject
     @Override
     public boolean spawnFromSapling(LocalWorld world, Random random, Rotation rotation, int x, int y, int z)
     {
-    	return spawnForced(world, random, rotation, x, y, z);
-    }
-
-    @Override
-    public boolean spawnForced(LocalWorld world, Random random, Rotation rotation, int x, int y, int z)
-    {
         BO3BlockFunction[] blocks = settings.getBlocks(rotation.getRotationId());
 
         ArrayList<BO3BlockFunction> blocksToSpawn = new ArrayList<BO3BlockFunction>();
@@ -120,9 +114,9 @@ public class BO3 implements StructuredCustomObject
         DefaultMaterial material;
         for (BO3BlockFunction block : blocks)
         {
-        	localMaterial = world.getMaterial(x + block.x, y + block.y, z + block.z, null);
+            localMaterial = world.getMaterial(x + block.x, y + block.y, z + block.z, null);
             material = localMaterial.toDefaultMaterial();
-            
+
             // Ignore blocks in the ground when checking spawn conditions
             if (block.y >= 0)
             {
@@ -132,7 +126,7 @@ public class BO3 implements StructuredCustomObject
                     return false;
                 }
             }
-            
+
             // Only overwrite air
             if (localMaterial.isAir())
             {
@@ -140,18 +134,36 @@ public class BO3 implements StructuredCustomObject
                 blocksToSpawn.add(block);
             }
 
-            if (block instanceof BO3BlockFunction)
-            {
-                oeh.addBlock((BO3BlockFunction) block);
-            }
-
+            oeh.addBlock((BO3BlockFunction) block);
         }
-
-        // Spawn
-
-        for (BO3BlockFunction block : blocksToSpawn)
-        {
+        for (BO3BlockFunction block : blocksToSpawn) {
             block.spawn(world, random, x + block.x, y + block.y, z + block.z, null);
+        }
+        oeh.extrude(world, random, x, y, z, null);
+        handleBO3Functions(null, world, random, rotation, x, y, z, chunks, null);
+
+        return true;
+    }
+
+    // Force spawns a BO3 object. Used by /otg spawn and bo3AtSpawn.
+    // This method ignores the maxPercentageOutsideBlock setting
+    @Override
+    public boolean spawnForced(LocalWorld world, Random random, Rotation rotation, int x, int y, int z)
+    {
+        BO3BlockFunction[] blocks = settings.getBlocks(rotation.getRotationId());
+        ObjectExtrusionHelper oeh = new ObjectExtrusionHelper(settings.extrudeMode, settings.extrudeThroughBlocks);
+        HashSet<ChunkCoordinate> chunks = new HashSet<ChunkCoordinate>();
+
+        for (BO3BlockFunction block : blocks)
+        {
+            // Places if BO3 is in placeAnyway mode, or if target block is a source block
+            if (settings.outsideSourceBlock == OutsideSourceBlock.placeAnyway
+                    || settings.sourceBlocks.contains(block.material))
+            {
+                block.spawn(world, random, x + block.x, y + block.y, z + block.z, null);
+                oeh.addBlock(block);
+                chunks.add(ChunkCoordinate.fromBlockCoords(x + block.x, z + block.z));
+            }
         }
 
         oeh.extrude(world, random, x, y, z, null);

--- a/common/src/main/java/com/pg85/otg/generator/ObjectSpawner.java
+++ b/common/src/main/java/com/pg85/otg/generator/ObjectSpawner.java
@@ -153,6 +153,7 @@ public class ObjectSpawner
 			world.getStructureCache().plotStructures(rand, chunkCoord, false);
 
 	        ChunkCoordinate spawnChunk = this.world.getSpawnChunk();
+			WorldConfig worldConfig = configProvider.getWorldConfig();
 
 	        boolean hasVillage = false;
 
@@ -175,7 +176,11 @@ public class ObjectSpawner
 	        			}
 	        			else if(((BO3)customObject).getSettings().spawnHeight == SpawnHeightEnum.randomY)
 	        			{
-	        				y = (int) (((BO3)customObject).getSettings().minHeight + (Math.random() * (((BO3)customObject).getSettings().maxHeight - ((BO3)customObject).getSettings().minHeight)));
+							if (worldConfig.spawnPointSet)
+							{
+								y = worldConfig.spawnPointY;
+							}
+							else y = (int) (((BO3)customObject).getSettings().minHeight + (Math.random() * (((BO3)customObject).getSettings().maxHeight - ((BO3)customObject).getSettings().minHeight)));
 	        			}
 
 	        			y += ((BO3)customObject).getSettings().spawnHeightOffset;
@@ -189,7 +194,7 @@ public class ObjectSpawner
 	        }
 
 			// Get the random generator
-			WorldConfig worldConfig = configProvider.getWorldConfig();
+
 			long resourcesSeed = worldConfig.resourcesSeed != 0L ? worldConfig.resourcesSeed : world.getSeed();
 			this.rand.setSeed(resourcesSeed);
 			long l1 = this.rand.nextLong() / 2L * 2L + 1L;
@@ -261,12 +266,20 @@ public class ObjectSpawner
 	        			}
 	        			else if(((BO3)customObject).getSettings().spawnHeight == SpawnHeightEnum.randomY)
 	        			{
-	        				y = (int) (((BO3)customObject).getSettings().minHeight + (Math.random() * (((BO3)customObject).getSettings().maxHeight - ((BO3)customObject).getSettings().minHeight)));
+							if (worldConfig.spawnPointSet)
+							{
+								y = worldConfig.spawnPointY;
+							}
+							else y = (int) (((BO3)customObject).getSettings().minHeight + (Math.random() * (((BO3)customObject).getSettings().maxHeight - ((BO3)customObject).getSettings().minHeight)));
 	        			}
 
 	        			y += ((BO3)customObject).getSettings().spawnHeightOffset;
 	        			// TODO: This may spawn the structure across chunk borders if its larger than 16 in any direction from its center.
-	        			((BO3)customObject).spawnForced(this.world, this.rand, Rotation.NORTH, spawnChunk.getBlockX() + 15, y, spawnChunk.getBlockZ() + 15);
+	        			boolean ret = ((BO3)customObject).spawnForced(this.world, this.rand, Rotation.NORTH, spawnChunk.getBlockX() + 15, y, spawnChunk.getBlockZ() + 15);
+	        			if (!ret)
+	        			{
+	        				OTG.log(LogMarker.ERROR, "Failed to spawn bo3AtSpawn object");
+						}
 	        		}
 	        	}
 	        } else {

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/dimensions/OTGWorldProvider.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/dimensions/OTGWorldProvider.java
@@ -166,12 +166,16 @@ public class OTGWorldProvider extends WorldProviderSurface
     	DimensionConfig dimConfig = getDimensionConfig();   	
     	if(dimConfig != null && dimConfig.Settings.SpawnPointSet)
     	{
+    	    int randX = 0, randZ = 0;
 			// Calculate random spawn position within a circular radius around the spawn coords
-			Random rand = new Random();	    			
-			int randX = -dimConfig.GameRules.SpawnRadius + rand.nextInt(dimConfig.GameRules.SpawnRadius * 2);
-			// MaxZ = sqrt(spawnradius^2 - randX^2)
-			int maxZ =  (int)Math.floor(Math.sqrt((dimConfig.GameRules.SpawnRadius * dimConfig.GameRules.SpawnRadius) - (randX * randX)));
-			int randZ = maxZ == 0 ? 0 : -maxZ + rand.nextInt(maxZ * 2);
+            if (dimConfig.GameRules.SpawnRadius != 0)
+            {
+                Random rand = new Random();
+                randX = -dimConfig.GameRules.SpawnRadius + rand.nextInt(dimConfig.GameRules.SpawnRadius * 2);
+                // MaxZ = sqrt(spawnradius^2 - randX^2)
+                int maxZ =  (int)Math.floor(Math.sqrt((dimConfig.GameRules.SpawnRadius * dimConfig.GameRules.SpawnRadius) - (randX * randX)));
+                randZ = maxZ == 0 ? 0 : -maxZ + rand.nextInt(maxZ * 2);
+            }
 
 			return new BlockPos(this.world.getWorldInfo().getSpawnX() + randX, this.world.getWorldInfo().getSpawnY(), this.world.getWorldInfo().getSpawnZ() + randZ);
     	} else {


### PR DESCRIPTION
- Fixed /otg spawn often not spawning anything
- Fixed BO3AtSpawn not spawning under certain conditions
- Made RandomY spawn-BO3's generate at player's spawn point, to allow for underground spawning
- Fixed spawn radius 0 throwing an error