### PR TITLE
Biome smoothing improvements

### DIFF
--- a/common/src/main/java/com/pg85/otg/configuration/standard/WorldStandardValues.java
+++ b/common/src/main/java/com/pg85/otg/configuration/standard/WorldStandardValues.java
@@ -170,6 +170,7 @@ public class WorldStandardValues extends Settings
 		IMPROVED_BIOME_BORDERS = booleanSetting("ImprovedBiomeBorders", false),
 		IMPROVED_BIOME_GROUPS = booleanSetting("ImprovedBiomeGroups", false),
 		CUSTOM_HEIGHT_CONTROL_SMOOTHING = booleanSetting("CustomHeightControlSmoothing", false),
+		IMPROVED_SMOOTHING = booleanSetting("ImprovedSmoothing", false),
 
 		TeleportToSpawnOnly = booleanSetting("TeleportToSpawnOnly", false),
 		CommandBlockOutput = booleanSetting("CommandBlockOutput", true),

--- a/common/src/main/java/com/pg85/otg/configuration/standard/WorldStandardValues.java
+++ b/common/src/main/java/com/pg85/otg/configuration/standard/WorldStandardValues.java
@@ -169,6 +169,7 @@ public class WorldStandardValues extends Settings
         POPULATE_USING_SAVED_BIOMES = booleanSetting("PopulateUsingSavedBiomes", false),
 		IMPROVED_BIOME_BORDERS = booleanSetting("ImprovedBiomeBorders", false),
 		IMPROVED_BIOME_GROUPS = booleanSetting("ImprovedBiomeGroups", false),
+		CUSTOM_HEIGHT_CONTROL_SMOOTHING = booleanSetting("CustomHeightControlSmoothing", false),
 
 		TeleportToSpawnOnly = booleanSetting("TeleportToSpawnOnly", false),
 		CommandBlockOutput = booleanSetting("CommandBlockOutput", true),

--- a/common/src/main/java/com/pg85/otg/configuration/world/WorldConfig.java
+++ b/common/src/main/java/com/pg85/otg/configuration/world/WorldConfig.java
@@ -51,7 +51,8 @@ public class WorldConfig extends ConfigFile
 
     public boolean improvedBiomeBorders;
     public boolean improvedBiomeGroups;
-    
+    public boolean customHeightControlSmoothing;
+
     // Dimensions
     public List<String> dimensions = new ArrayList<String>();
 
@@ -628,6 +629,7 @@ public class WorldConfig extends ConfigFile
         readCustomBiomes(reader);
 
         this.improvedBiomeBorders = reader.getSetting(WorldStandardValues.IMPROVED_BIOME_BORDERS);
+        this.customHeightControlSmoothing = reader.getSetting(WorldStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTHING);
         this.improvedBiomeGroups = reader.getSetting(WorldStandardValues.IMPROVED_BIOME_GROUPS);
         
         // Images
@@ -995,7 +997,10 @@ public class WorldConfig extends ConfigFile
         		"Spawns more precise borders that never spill over into neighbouring biomes. Disabled by default for legacy worlds.");
 
         writer.putSetting(WorldStandardValues.IMPROVED_BIOME_GROUPS, this.improvedBiomeGroups,
-        		"Fixes biome groups not changing with seeds. Disabled by default for legacy worlds.");        
+        		"Fixes biome groups not changing with seeds. Disabled by default for legacy worlds.");
+
+        writer.putSetting(WorldStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTHING, this.customHeightControlSmoothing,
+                "Smooths biome CustomHeightControl data. Disabled by default for legacy worlds.");
 
         writer.smallTitle("Landmass settings (for NormalBiomes)");
 

--- a/common/src/main/java/com/pg85/otg/configuration/world/WorldConfig.java
+++ b/common/src/main/java/com/pg85/otg/configuration/world/WorldConfig.java
@@ -52,6 +52,7 @@ public class WorldConfig extends ConfigFile
     public boolean improvedBiomeBorders;
     public boolean improvedBiomeGroups;
     public boolean customHeightControlSmoothing;
+    public boolean improvedSmoothing;
 
     // Dimensions
     public List<String> dimensions = new ArrayList<String>();
@@ -629,8 +630,9 @@ public class WorldConfig extends ConfigFile
         readCustomBiomes(reader);
 
         this.improvedBiomeBorders = reader.getSetting(WorldStandardValues.IMPROVED_BIOME_BORDERS);
-        this.customHeightControlSmoothing = reader.getSetting(WorldStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTHING);
         this.improvedBiomeGroups = reader.getSetting(WorldStandardValues.IMPROVED_BIOME_GROUPS);
+        this.customHeightControlSmoothing = reader.getSetting(WorldStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTHING);
+        this.improvedSmoothing = reader.getSetting(WorldStandardValues.IMPROVED_SMOOTHING);
         
         // Images
         this.imageMode = reader.getSetting(WorldStandardValues.IMAGE_MODE);
@@ -1001,6 +1003,9 @@ public class WorldConfig extends ConfigFile
 
         writer.putSetting(WorldStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTHING, this.customHeightControlSmoothing,
                 "Smooths biome CustomHeightControl data. Disabled by default for legacy worlds.");
+
+        writer.putSetting(WorldStandardValues.IMPROVED_SMOOTHING, this.improvedSmoothing,
+                "Smooths volatility and max average data. Disabled by default for legacy worlds.");
 
         writer.smallTitle("Landmass settings (for NormalBiomes)");
 

--- a/common/src/main/java/com/pg85/otg/generator/ChunkProviderOTG.java
+++ b/common/src/main/java/com/pg85/otg/generator/ChunkProviderOTG.java
@@ -632,6 +632,9 @@ public class ChunkProviderOTG
         {
             for (int nextZ = -lookRadius; nextZ <= lookRadius; nextZ++)
             {
+                // Weight is done on a 2d scale, so add that outside of the loop
+                weightSum += 1;
+
                 // Compute the data for each column
                 for (int y = 0; y < maxYSections; y++)
                 {
@@ -641,7 +644,6 @@ public class ChunkProviderOTG
                     // Add the custom height for both river and normal CHC
                     riverData[y] += nextBiomeConfig.riverHeightMatrix[Math.min(nextBiomeConfig.riverHeightMatrix.length - 1, y)];
                     chcData[y] += nextBiomeConfig.heightMatrix[Math.min(nextBiomeConfig.heightMatrix.length - 1, y)];
-                    weightSum += 1;
                 }
             }
         }


### PR DESCRIPTION
- Adds smoothing for CustomHeightControl, RiverCustomHeightControl, volatility1, volatility2, volatilityWeight1, volatilityWeight2, maxAverageDepth, maxAverageHeight
- Cleans up some local variable names and adds comments
The documentation isn't fully complete, in the future I'd like the entire terrain generation pipeline to be fully documented and cleaned up.