### PR TITLE
add separate CHC smoothing

### DIFF
--- a/common/src/main/java/com/pg85/otg/configuration/biome/BiomeConfig.java
+++ b/common/src/main/java/com/pg85/otg/configuration/biome/BiomeConfig.java
@@ -58,6 +58,7 @@ public class BiomeConfig extends ConfigFile
     public float biomeHeight;
     public float biomeVolatility;
     public int smoothRadius;
+    public int CHCSmoothRadius;
 
     public float biomeTemperature;
     public float biomeWetness;
@@ -319,6 +320,7 @@ public class BiomeConfig extends ConfigFile
         this.biomeHeight = settings.getSetting(BiomeStandardValues.BIOME_HEIGHT, defaultSettings.defaultBiomeSurface);
         this.biomeVolatility = settings.getSetting(BiomeStandardValues.BIOME_VOLATILITY, defaultSettings.defaultBiomeVolatility);
         this.smoothRadius = settings.getSetting(BiomeStandardValues.SMOOTH_RADIUS);
+        this.CHCSmoothRadius = settings.getSetting(BiomeStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTH_RADIUS);
 
         this.stoneBlock = settings.getSetting(BiomeStandardValues.STONE_BLOCK);
         this.surfaceBlock = settings.getSetting(BiomeStandardValues.SURFACE_BLOCK,
@@ -565,6 +567,10 @@ public class BiomeConfig extends ConfigFile
                 "smooth radius seems to be  (thisSmoothRadius + 1 + smoothRadiusOfBiomeOnOtherSide) * 4 .",
                 "So if two biomes next to each other have both a smooth radius of 2, the",
                 "resulting smooth area will be (2 + 1 + 2) * 4 = 20 blocks wide.");
+
+        writer.putSetting(BiomeStandardValues.CUSTOM_HEIGHT_CONTROL_SMOOTH_RADIUS, this.CHCSmoothRadius,
+                "Works the same way as SmoothRadius but only works on CustomHeightControl. Must be between 0 and 32, inclusive.",
+                "Does nothing if Custom Height Control smoothing is not enabled in the world config.");
 
         writer.putSetting(BiomeStandardValues.MAX_AVERAGE_HEIGHT, this.maxAverageHeight,
                 "If this value is greater than 0, then it will affect how much, on average, the terrain will rise before leveling off when it begins to increase in elevation.",

--- a/common/src/main/java/com/pg85/otg/configuration/standard/BiomeStandardValues.java
+++ b/common/src/main/java/com/pg85/otg/configuration/standard/BiomeStandardValues.java
@@ -50,6 +50,7 @@ public class BiomeStandardValues extends Settings
             BIOME_RARITY = intSetting("BiomeRarity", 100, 0, Integer.MAX_VALUE),
             BIOME_RARITY_WHEN_ISLE = intSetting("BiomeRarityWhenIsle", 100, 0, Integer.MAX_VALUE),
             SMOOTH_RADIUS = intSetting("SmoothRadius", 2, 0, 32),
+            CUSTOM_HEIGHT_CONTROL_SMOOTH_RADIUS = intSetting("CustomHeightControlSmoothRadius", 2, 0, 32),
             RIVER_WATER_LEVEL = intSetting("RiverWaterLevel", 63, PluginStandardValues.WORLD_DEPTH, PluginStandardValues.WORLD_HEIGHT - 1),
             WATER_LEVEL_MAX = WorldStandardValues.WATER_LEVEL_MAX,
             WATER_LEVEL_MIN = WorldStandardValues.WATER_LEVEL_MIN;

--- a/common/src/main/java/com/pg85/otg/generator/ChunkProviderOTG.java
+++ b/common/src/main/java/com/pg85/otg/generator/ChunkProviderOTG.java
@@ -646,7 +646,7 @@ public class ChunkProviderOTG
 
         // Gather center data
         final BiomeConfig centerBiomeConfig = toBiomeConfig(biomeArray[(x + this.maxSmoothRadius + (z + this.maxSmoothRadius) * (NOISE_MAX_X + this.maxSmoothDiameter))]);
-        final int lookRadius = centerBiomeConfig.smoothRadius;
+        final int lookRadius = centerBiomeConfig.CHCSmoothRadius;
 
         // Iterate through and add the chc
         for (int nextX = -lookRadius; nextX <= lookRadius; nextX++)

--- a/common/src/main/java/com/pg85/otg/network/ServerConfigProvider.java
+++ b/common/src/main/java/com/pg85/otg/network/ServerConfigProvider.java
@@ -781,6 +781,11 @@ public final class ServerConfigProvider implements ConfigProvider
             this.worldConfig.maxSmoothRadius = biomeConfig.smoothRadius;
         }
 
+		if (this.worldConfig.maxSmoothRadius < biomeConfig.CHCSmoothRadius)
+		{
+			this.worldConfig.maxSmoothRadius = biomeConfig.CHCSmoothRadius;
+		}
+
         // Indexing BiomeColor
         if (this.worldConfig.biomeMode == OTG.getBiomeModeManager().FROM_IMAGE)
         {


### PR DESCRIPTION
This PR moves the CHC smoothing radius to a separate `CustomHeightControlSmoothRadius` value to prevent unintended consequences from using the same smooth radius as the other values. This allows preset makers to have better control over their CHC smoothing. This change should not break any existing presets.