### PR TITLE
Small fixes - BO3 CustomStructures use two rarities & /otg export misalignment

### DIFF
--- a/common/src/main/java/com/pg85/otg/customobjects/bo3/BO3.java
+++ b/common/src/main/java/com/pg85/otg/customobjects/bo3/BO3.java
@@ -549,14 +549,10 @@ public class BO3 implements StructuredCustomObject
         return MathHelper.clamp(offset + variance, PluginStandardValues.WORLD_DEPTH, PluginStandardValues.WORLD_HEIGHT - 1);
     }
     
-    public CustomStructureCoordinate makeCustomObjectCoordinate(LocalWorld world, Random random, int chunkX, int chunkZ)
+    public CustomStructureCoordinate makeCustomStructureCoordinate(LocalWorld world, Random random, int chunkX, int chunkZ)
     {
-        if (settings.rarity > random.nextDouble() * 100.0)
-        {
-            Rotation rotation = settings.rotateRandomly ? Rotation.getRandomRotation(random) : Rotation.NORTH;
-            int height = RandomHelper.numberInRange(random, settings.minHeight, settings.maxHeight);
-            return new BO3CustomStructureCoordinate(world, this, this.getName(), rotation, chunkX * 16 + 8 + random.nextInt(16), (short)height, chunkZ * 16 + 7 + random.nextInt(16));
-        }
-        return null;
+        Rotation rotation = settings.rotateRandomly ? Rotation.getRandomRotation(random) : Rotation.NORTH;
+        int height = RandomHelper.numberInRange(random, settings.minHeight, settings.maxHeight);
+        return new BO3CustomStructureCoordinate(world, this, this.getName(), rotation, chunkX * 16 + 8 + random.nextInt(16), (short)height, chunkZ * 16 + 7 + random.nextInt(16));
     }    
 }

--- a/common/src/main/java/com/pg85/otg/generator/resource/CustomStructureGen.java
+++ b/common/src/main/java/com/pg85/otg/generator/resource/CustomStructureGen.java
@@ -92,7 +92,7 @@ public class CustomStructureGen extends Resource
             	StructuredCustomObject object = getObjects(world.getName()).get(objectNumber);
             	if(object != null && object instanceof BO3) // TODO: How could a BO4 end up here? seen it happen once..
             	{
-            		return (BO3CustomStructureCoordinate)((BO3)object).makeCustomObjectCoordinate(world, random, chunkX, chunkZ);
+            		return (BO3CustomStructureCoordinate)((BO3)object).makeCustomStructureCoordinate(world, random, chunkX, chunkZ);
             	} else {
             		if(OTG.getPluginConfig().spawnLog)
             		{

--- a/platforms/bukkit/src/main/java/com/pg85/otg/bukkit/util/BO3Creator.java
+++ b/platforms/bukkit/src/main/java/com/pg85/otg/bukkit/util/BO3Creator.java
@@ -135,9 +135,13 @@ public class BO3Creator extends BOCreator
 
         if (centerBlock == null || !centerBlockFound)
         {
-            centerPointX = (int) Math.floor((start.getBlockX() + end.getBlockX()) / 2d);
+            centerPointX = (start.getBlockX() + end.getBlockX()) >> 1;
             centerPointY = start.getBlockY();
-            centerPointZ = (int) Math.floor((start.getBlockZ() + end.getBlockZ()) / 2d);
+            int z = (start.getBlockZ() + end.getBlockZ()) >> 1;
+            // For 16x16 objects, z should be 7 to place correctly as a BO4
+            if (width == 16)
+                z--;
+            centerPointZ = z;
         }
 
         Map<ChunkCoordIntPair, List<BO3BlockFunction>> blocksPerChunkArr = new HashMap<ChunkCoordIntPair, List<BO3BlockFunction>>();

--- a/platforms/bukkit/src/main/java/com/pg85/otg/bukkit/util/BO4Creator.java
+++ b/platforms/bukkit/src/main/java/com/pg85/otg/bukkit/util/BO4Creator.java
@@ -106,7 +106,11 @@ public class BO4Creator extends BOCreator
         {
             centerPointX = (start.getBlockX() + end.getBlockX()) >> 1;
             centerPointY = start.getBlockY();
-            centerPointZ = (start.getBlockZ() + end.getBlockZ()) >> 1;
+            int z = (start.getBlockZ() + end.getBlockZ()) >> 1;
+            // For 16x16 objects, z should be 7 to place correctly as a BO4
+            if (width == 16)
+                z--;
+            centerPointZ = z;
         }
 
         Map<ChunkCoordinate, ArrayList<BO4BlockFunction>> blocksPerChunkArr = new HashMap<ChunkCoordinate, ArrayList<BO4BlockFunction>>();

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/util/BO3Creator.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/util/BO3Creator.java
@@ -127,9 +127,13 @@ public class BO3Creator extends BOCreator
 
         if (centerBlock == null || !centerBlockFound)
         {
-            centerPointX = (int) Math.floor((start.getBlockX() + end.getBlockX()) / 2d);
+            centerPointX = (start.getBlockX() + end.getBlockX()) >> 1;
             centerPointY = start.getBlockY();
-            centerPointZ = (int) Math.floor((start.getBlockZ() + end.getBlockZ()) / 2d);
+            int z = (start.getBlockZ() + end.getBlockZ()) >> 1;
+            // For 16x16 objects, z should be 7 to place correctly as a BO4
+            if (width == 16)
+                z--;
+            centerPointZ = z;
         }
 
         Map<ChunkCoordinate, List<BO3BlockFunction>> blocksPerChunkArr = new HashMap<ChunkCoordinate, List<BO3BlockFunction>>();

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/util/BO4Creator.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/util/BO4Creator.java
@@ -104,7 +104,11 @@ public class BO4Creator extends BOCreator
         {
             centerPointX = (start.getBlockX() + end.getBlockX()) >> 1;
             centerPointY = start.getBlockY();
-            centerPointZ = (start.getBlockZ() + end.getBlockZ()) >> 1;
+            int z = (start.getBlockZ() + end.getBlockZ()) >> 1;
+            // For 16x16 objects, z should be 7 to place correctly as a BO4
+            if (width == 16)
+                z--;
+            centerPointZ = z;
         }
 
         Map<ChunkCoordinate, ArrayList<BO4BlockFunction>> blocksPerChunkArr = new HashMap<ChunkCoordinate, ArrayList<BO4BlockFunction>>();


### PR DESCRIPTION
BO3 CustomStructures were using BO3 rarity _in addition_ to object chance specified in resource queue, which both pitman and config comments say should not be the case. Removed the BO3 rarity from the process, and renamed the method to be more appropriate as it wasn't used by any other class.

BlackEagle found this, which seems relevant:
https://github.com/PG85/OpenTerrainGenerator/issues/160