### PR TITLE
PortalMobSpawnChance crash fix

### DIFF
--- a/platforms/forge/src/main/java/com/pg85/otg/forge/blocks/portal/BlockPortalOTG.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/blocks/portal/BlockPortalOTG.java
@@ -134,7 +134,8 @@ public class BlockPortalOTG extends BlockBreakableBase
         
     	ResourceLocation entityType = dimConfig == null ? new ResourceLocation("zombie_pigman") : new ResourceLocation(dimConfig.Settings.PortalMobType);
 
-        if (worldIn.provider.isSurfaceWorld() && worldIn.getGameRules().getBoolean("doMobSpawning") && rand.nextInt(dimConfig == null ? 2000 : dimConfig.Settings.PortalMobSpawnChance) < worldIn.getDifficulty().getId())
+	    int spawnChance = (dimConfig == null ? 2000 : dimConfig.Settings.PortalMobSpawnChance);
+        if (worldIn.provider.isSurfaceWorld() && worldIn.getGameRules().getBoolean("doMobSpawning") && spawnChance > 0 && rand.nextInt(spawnChance) < worldIn.getDifficulty().getId())
         {
             int i = pos.getY();
             BlockPos blockpos;


### PR DESCRIPTION
Fix crash due to PortalMobSpawnChance <= 0, a value of 0 or below will now result in no spawns.