### PR TITLE
1.16.5 - 0.0.10: Spigot bo4's hang fix, version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ defaultTasks 'clean', 'build', 'createReleaseJar', 'install'
 
 allprojects
 {
-    version = "1.16.5-0.0.9"
+    version = "1.16.5-0.0.10"
     group = "com.pg85.otg"
 
     // Version of the shadow plugin

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/OTGNoiseChunkGenerator.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/OTGNoiseChunkGenerator.java
@@ -708,6 +708,7 @@ public class OTGNoiseChunkGenerator extends ChunkGenerator
 		// Setup jigsaw data
 		ObjectList<JigsawStructureData> structures = new ObjectArrayList<>(10);
 		ObjectList<JigsawStructureData> junctions = new ObjectArrayList<>(32);
+		/*
 		ChunkCoordIntPair pos = chunk.getPos();
 		int chunkX = pos.x;
 		int chunkZ = pos.z;
@@ -749,6 +750,7 @@ public class OTGNoiseChunkGenerator extends ChunkGenerator
 
 			});
 		}
+		*/
 
 		this.internalGenerator.populateNoise(this.preset.getWorldConfig().getWorldHeightCap(), random, buffer, buffer.getChunkCoordinate(), structures, junctions);
 		return chunk;


### PR DESCRIPTION
- Fixes hang on world creation for bo4 worlds for spigot, still plenty of bo4 bugs left though.