### PR TITLE
1.16.4 dev pg

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ defaultTasks 'clean', 'build', 'createReleaseJar', 'install'
 
 allprojects
 {
-    version = "1.16.5-0.0.10"
+    version = "1.16.5-0.0.11"
     group = "com.pg85.otg"
 
     // Version of the shadow plugin

--- a/common/common-core/src/main/java/com/pg85/otg/config/biome/BiomeConfig.java
+++ b/common/common-core/src/main/java/com/pg85/otg/config/biome/BiomeConfig.java
@@ -264,17 +264,6 @@ public class BiomeConfig extends BiomeConfigBase
 		this.replacedBlocks = reader.getSetting(BiomeStandardValues.REPLACED_BLOCKS, logger, materialReader);
 		this.sandStoneBlock = LocalMaterials.SANDSTONE;
 		this.redSandStoneBlock = LocalMaterials.RED_SANDSTONE;
-		this.replacedBlocks.init(
-			this.useWorldWaterLevel ? worldConfig.getCooledLavaBlock() : this.configCooledLavaBlock,
-			this.useWorldWaterLevel ? worldConfig.getIceBlock() : this.configIceBlock,
-			this.useWorldWaterLevel ? worldConfig.getWaterBlock() : this.configWaterBlock,
-			this.stoneBlock,
-			this.groundBlock,
-			this.surfaceBlock,
-			this.worldConfig.getDefaultBedrockBlock(),
-			this.sandStoneBlock,
-			this.redSandStoneBlock
-		);
 		this.surfaceAndGroundControl = readSurfaceAndGroundControlSettings(reader, logger, materialReader);
 		this.useWorldWaterLevel = reader.getSetting(BiomeStandardValues.USE_WORLD_WATER_LEVEL, logger);
 		this.configWaterLevelMax = reader.getSetting(BiomeStandardValues.WATER_LEVEL_MAX, logger);

--- a/common/common-core/src/main/java/com/pg85/otg/config/biome/BiomeConfigBase.java
+++ b/common/common-core/src/main/java/com/pg85/otg/config/biome/BiomeConfigBase.java
@@ -39,6 +39,7 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	// Misc
 	
 	private final BiomeResourceLocation registryKey;
+	private boolean replacedBlocksInited = false;
 	
 	// TODO: Ideally, don't contain worldConfig within biomeconfig,  
 	// use a parent object that holds both, like a worldgenregion.
@@ -96,7 +97,7 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	
 	// Water / lava / freezing
 	
-	protected boolean useWorldWaterLevel;	
+	protected boolean useWorldWaterLevel;
 	protected int waterLevelMax;
 	protected int waterLevelMin;
 	protected LocalMaterialData waterBlock;
@@ -200,12 +201,31 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 		return this.groundBlock;
 	}
 	
+	private void initReplaceBlocks()
+	{
+		if(!this.replacedBlocksInited)
+		{
+			this.replacedBlocks.init(
+				this.useWorldWaterLevel ? worldConfig.getCooledLavaBlock() : this.cooledLavaBlock,
+				this.useWorldWaterLevel ? worldConfig.getIceBlock() : this.iceBlock,
+				this.useWorldWaterLevel ? worldConfig.getWaterBlock() : this.waterBlock,
+				this.stoneBlock,
+				this.groundBlock,
+				this.surfaceBlock,
+				this.worldConfig.getDefaultBedrockBlock(),
+				this.sandStoneBlock,
+				this.redSandStoneBlock
+			);
+		}
+		this.replacedBlocksInited = true;
+	}
+	
 	@Override
 	public LocalMaterialData getSurfaceBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesSurface)
+		if(getReplaceBlocks().replacesSurface)
 		{
-			return this.surfaceBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.surfaceBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.surfaceBlock;
 	}
@@ -213,9 +233,9 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	@Override
 	public LocalMaterialData getGroundBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesGround)
+		if(getReplaceBlocks().replacesGround)
 		{
-			return this.groundBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.groundBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.groundBlock;
 	}
@@ -223,9 +243,9 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	@Override
 	public LocalMaterialData getStoneBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesStone)
+		if(getReplaceBlocks().replacesStone)
 		{
-			return this.stoneBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.stoneBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.stoneBlock;
 	}
@@ -233,15 +253,15 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	@Override
 	public LocalMaterialData getBedrockBlockReplaced(int y)
 	{
-		return this.worldConfig.getBedrockBlockReplaced(this.replacedBlocks, y);
+		return this.worldConfig.getBedrockBlockReplaced(getReplaceBlocks(), y);
 	}
 		
 	@Override
 	public LocalMaterialData getWaterBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesWater)
+		if(getReplaceBlocks().replacesWater)
 		{
-			return this.waterBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.waterBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.waterBlock;
 	}
@@ -249,9 +269,9 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	@Override
 	public LocalMaterialData getSandStoneBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesSandStone)
+		if(getReplaceBlocks().replacesSandStone)
 		{
-			return this.sandStoneBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.sandStoneBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.sandStoneBlock;
 	}
@@ -259,9 +279,9 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	@Override
 	public LocalMaterialData getIceBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesIce)
+		if(getReplaceBlocks().replacesIce)
 		{
-			return this.iceBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.iceBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.iceBlock;
 	}
@@ -269,16 +289,23 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	@Override
 	public LocalMaterialData getCooledLavaBlockReplaced(int y)
 	{
-		if(this.replacedBlocks.replacesCooledLava)
+		if(getReplaceBlocks().replacesCooledLava)
 		{
-			return this.cooledLavaBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), this.replacedBlocks, y);
+			return this.cooledLavaBlock.parseWithBiomeAndHeight(this.worldConfig.getBiomeConfigsHaveReplacement(), getReplaceBlocks(), y);
 		}
 		return this.cooledLavaBlock;
 	}
 	
 	@Override
+	public boolean hasReplaceBlocksSettings()
+	{
+		return this.replacedBlocks.hasReplaceSettings();
+	}
+	
+	@Override
 	public ReplacedBlocksMatrix getReplaceBlocks()
 	{
+		initReplaceBlocks();
 		return this.replacedBlocks;
 	}
 

--- a/common/common-core/src/main/java/com/pg85/otg/presets/LocalPresetLoader.java
+++ b/common/common-core/src/main/java/com/pg85/otg/presets/LocalPresetLoader.java
@@ -208,7 +208,7 @@ public abstract class LocalPresetLoader
 			// Index ReplacedBlocks
 			if (!worldConfig.getBiomeConfigsHaveReplacement())
 			{
-				worldConfig.setBiomeConfigsHaveReplacement(biomeConfig.getReplaceBlocks().hasReplaceSettings());
+				worldConfig.setBiomeConfigsHaveReplacement(biomeConfig.hasReplaceBlocksSettings());
 			}
 
 			// Index maxSmoothRadius

--- a/common/common-util/src/main/java/com/pg85/otg/util/helpers/StringHelper.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/helpers/StringHelper.java
@@ -12,6 +12,8 @@ import java.util.List;
  */
 public abstract class StringHelper
 {
+    private StringHelper() { }
+	
     public static String join(final Collection<?> coll, final String glue)
     {
         return join(coll.toArray(new Object[coll.size()]), glue);
@@ -174,38 +176,6 @@ public abstract class StringHelper
             output = buffer.toArray(output);
 
         return output;
-    }
-
-    /**
-     * Gets whether the input specifies which block data should be used.
-     * <p>
-     * A few examples: "WOOL" doesn't specify block data, while "WOOL:0" does.
-     * "buildcraft:blockRedLaser" doesn't specify block data, even though it
-     * contains a colon. However, "buildcraft:blockRedLaser:0" does specify
-     * block data.
-     * 
-     * @param materialString
-     *            The input.
-     * @return True if the input specifies block data, false otherwise.
-     */
-    public static boolean specifiesBlockData(String materialString) {
-        int indexOfColon = materialString.lastIndexOf(":");
-        if (indexOfColon > 0)
-        {
-            String blockDataString = materialString.substring(indexOfColon + 1);
-            try {
-                Integer.parseInt(blockDataString);
-                // If we have reached this point, the text after the last colon
-                // was numeric, so it was indeed block data
-                return true;
-            } catch (NumberFormatException e) {
-            }
-        }
-        return false;
-    }
-
-    private StringHelper()
-    {
     }
 
     /**

--- a/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IBiomeConfig.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IBiomeConfig.java
@@ -98,6 +98,7 @@ public interface IBiomeConfig
 	LocalMaterialData getSandStoneBlockReplaced(int y);
 	LocalMaterialData getDefaultGroundBlock();
 	void doSurfaceAndGroundControl(long worldSeed, GeneratingChunk generatingChunk, ChunkBuffer chunkBuffer, IBiomeConfig biomeConfig, int x, int z);
+	boolean hasReplaceBlocksSettings();
 	ReplacedBlocksMatrix getReplaceBlocks();
 	
 	// Water / lava / freezing
@@ -174,5 +175,5 @@ public interface IBiomeConfig
 	List<WeightedMobSpawnGroup> getWaterCreatures();
 	List<WeightedMobSpawnGroup> getAmbientCreatures();	
 	List<WeightedMobSpawnGroup> getWaterAmbientCreatures();
-	List<WeightedMobSpawnGroup> getMiscCreatures();
+	List<WeightedMobSpawnGroup> getMiscCreatures();	
 }

--- a/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IMaterialReader.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IMaterialReader.java
@@ -2,8 +2,11 @@ package com.pg85.otg.util.interfaces;
 
 import com.pg85.otg.exception.InvalidConfigException;
 import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterialTag;
 
 public interface IMaterialReader
 {
 	public LocalMaterialData readMaterial(String string) throws InvalidConfigException;
+	
+	public LocalMaterialTag readTag(String string) throws InvalidConfigException;
 }

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterialBase.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterialBase.java
@@ -1,0 +1,12 @@
+package com.pg85.otg.util.materials;
+
+/**
+ * Represents one of Minecraft's materials.
+ * Immutable.
+ */
+public abstract class LocalMaterialBase
+{
+	// Used instead of instanceof to check between materials/tags
+	// TODO: Make this prettier, avoid requiring type checks altogether.
+	public abstract boolean isTag();
+}

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterialData.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterialData.java
@@ -2,17 +2,11 @@ package com.pg85.otg.util.materials;
 
 import com.pg85.otg.util.biome.ReplacedBlocksMatrix;
 
-// TODO: Make this class unmodifiable (parseForWorld modifies atm),
-// implement a world-specific materials cache and ensure only one
-// instance of each unique material (id+metadata) exists in memory.
-// TODO: Do creation of new material instances in one place only?
-
 /**
- * Represents one of Minecraft's materials. Also includes its data value.
+ * Represents one of Minecraft's materials.
  * Immutable.
- *
  */
-public abstract class LocalMaterialData
+public abstract class LocalMaterialData extends LocalMaterialBase
 {
 	protected String rawEntry;
 	protected boolean isBlank = false;
@@ -20,55 +14,29 @@ public abstract class LocalMaterialData
 	protected boolean parsedDefaultMaterial = false;
 	protected LocalMaterialData[] rotations = new LocalMaterialData[] {this, null, null, null};
 	protected LocalMaterialData rotated = null;
-	   
-    /**
-     * Gets the name of this material. If a {#toDefaultMaterial()
-     * DefaultMaterial is available,} that name is used, otherwise it's up to
-     * the mod that provided this block to name it. Block data is appended to
-     * the name, separated with a colon, like "WOOL:2".
-     * 
-     * @return The name of this material.
-     */
+
+	public abstract <T extends Comparable<T>> LocalMaterialData withProperty(MaterialProperty<T> state, T value);
+	
 	public abstract String getName();
 	
-    /**
-     * Gets whether this material is a liquid, like water or lava.
-     * 
-     * @return True if this material is a liquid, false otherwise.
-     */
+    public abstract boolean canSnowFallOn();
+    
+    public abstract boolean canFall();
+	
+    public abstract boolean isMaterial(LocalMaterialData material);
+	
+	public abstract boolean isBlockTag(LocalMaterialTag tag);
+    
     public abstract boolean isLiquid();
 
-    /**
-     * Gets whether this material is solid. If there is a
-     * { #toDefaultMaterial() DefaultMaterial available}, this property is
-     * defined by { DefaultMaterial#isSolid()}. Otherwise, it's up to the
-     * mod that provided this block to say whether it's solid or not.
-     * 
-     * @return True if this material is solid, false otherwise.
-     */
     public abstract boolean isSolid();
 
-    /**
-     * Gets whether this material is air. This is functionally equivalent to
-     * {@code isMaterial(DefaultMaterial.AIR)}, but may yield better
-     * performance.
-     * @return True if this material is air, false otherwise.
-     */
     public abstract boolean isEmptyOrAir();
     
     public abstract boolean isAir();
 
     public abstract boolean isEmpty();
-    
-    /**
-     * Gets whether snow can fall on this block.
-     * 
-     * @return True if snow can fall on this block, false otherwise.
-     */
-    public abstract boolean canSnowFallOn();
-
-    public abstract boolean isMaterial(LocalMaterialData material);
-    
+       
     public boolean isLogOrLeaves()
     {
 		return isLog() || isLeaves();
@@ -89,127 +57,10 @@ public abstract class LocalMaterialData
 			isMaterial(LocalMaterials.STRIPPED_OAK_LOG) ||
 			isMaterial(LocalMaterials.STRIPPED_SPRUCE_LOG);
 	}
-    
-    public boolean isLeaves()
-    {
-		return
-			isMaterial(LocalMaterials.ACACIA_LEAVES) ||
-			isMaterial(LocalMaterials.BIRCH_LEAVES) ||
-			isMaterial(LocalMaterials.DARK_OAK_LEAVES) ||
-			isMaterial(LocalMaterials.JUNGLE_LEAVES) ||
-			isMaterial(LocalMaterials.OAK_LEAVES) ||
-			isMaterial(LocalMaterials.SPRUCE_LEAVES);
-    }
-    
+        
     /**
-     * Gets an instance with the same material as this object, but the default
-     * block data of the material. This instance is not modified.
-     *
-     * @return An instance with the default block data.
-     */
-    public abstract LocalMaterialData withDefaultBlockData();
-
-    /**
-     * Gets whether this material equals another material. The block data is
-     * taken into account.
-     * 
-     * @param other
-     *            The other material.
-     * @return True if the materials are equal, false otherwise.
-     */
-    public abstract boolean equals(Object other);
-    
-    /**
-     * Gets the hashCode of the material, based on the block id and block data.
-     * The hashCode must be unique, which is possible considering that there are
-     * only 4096 * 16 possible materials.
-     * 
-     * @return The unique hashCode.
-     */
-    public abstract int hashCode();
-    
-    public String toString()
-    {
-    	return getName();
-    }   
-
-    /**
-     * Gets a new material that is rotated 90 degrees. North -> west -> south ->
-     * east. If this material cannot be rotated, the material itself is
-     * returned.
-     * 
-     * @return The rotated material.
-     */
-    public LocalMaterialData rotate()
-    {
-    	return rotate(1);
-    }
-    
-    /**
-     * Gets a new material that is rotated 90 degrees. North -> west -> south ->
-     * east. If this material cannot be rotated, the material itself is
-     * returned.
-     * 
-     * @return The rotated material.
-     */
-    public LocalMaterialData rotate(int rotateTimes)
-    {
-    	// TODO: Rotate modded blocks?
-    	
-    	// TODO: Reimplement this when block data has been implemented
-    	/*    	
-        // Try to rotate
-        DefaultMaterial defaultMaterial = toDefaultMaterial();
-        if (defaultMaterial != null)
-        {
-            // We only know how to rotate vanilla blocks
-        	byte blockDataByte = 0;
-            int newData = 0;
-            for(int i = 0; i < rotateTimes; i++)
-            {
-            	blockDataByte = getBlockData();
-            	newData = BlockHelper.rotateData(defaultMaterial, blockDataByte);	
-            }
-            if (newData != blockDataByte)
-            {
-            	return ofDefaultMaterialPrivate(defaultMaterial, newData);
-            }
-        }
-        */
-
-        // No changes, return object itself
-        return this;
-    }
-
-    /**
-     * Parses this material through the fallback system of the world if required.
-     * 
-     * @param replaceBlocks The replaceblocks matrix to use.
-     * @return The parsed material
-     */
-    //public abstract LocalMaterialData parseForWorld(WorldConfig worldConfig);
-    
-	public LocalMaterialData parseWithBiomeAndHeight(boolean biomeConfigsHaveReplacement, ReplacedBlocksMatrix replaceBlocks, int y)
-	{	
-        if (!biomeConfigsHaveReplacement)
-        {
-            // Don't waste time here, ReplacedBlocks is empty everywhere
-            return this;
-        }
-        return replaceBlocks.replaceBlock(y, this);
-	}
-
-    /**
-     * Gets whether this material falls down when no other block supports this
-     * block, like gravel and sand do.
-     * @return True if this material can fall, false otherwise.
-     */
-    public abstract boolean canFall();
-    
-    /**
-     * Gets whether this material can be used as an anchor point for a smooth area    
-     * 
-     * @return True if this material is a solid block, false if it is a tile-entity, half-slab, stairs(?), water, wood or leaves
+     * Gets whether this material can be used as an anchor point for a smoothing area    
+     * @return True if this material is a solid block, false if it is a tile-entity, half-slab, stairs(?), water, wood or leaves.
      */    
     public boolean isSmoothAreaAnchor(boolean allowWood, boolean ignoreWater)
     {
@@ -254,8 +105,55 @@ public abstract class LocalMaterialData
 			isMaterial(LocalMaterials.REDSTONE_ORE)
 		;
 	}
+	
+    public boolean isLeaves()
+    {
+		return
+			isMaterial(LocalMaterials.ACACIA_LEAVES) ||
+			isMaterial(LocalMaterials.BIRCH_LEAVES) ||
+			isMaterial(LocalMaterials.DARK_OAK_LEAVES) ||
+			isMaterial(LocalMaterials.JUNGLE_LEAVES) ||
+			isMaterial(LocalMaterials.OAK_LEAVES) ||
+			isMaterial(LocalMaterials.SPRUCE_LEAVES);
+    }
 
-	public abstract <T extends Comparable<T>> LocalMaterialData withProperty(MaterialProperty<T> state, T value);
+    /**
+     * Gets a new material that is rotated 90 degrees. North -> west -> south ->
+     * east. If this material cannot be rotated, the material itself is
+     * returned.
+     * 
+     * @return The rotated material.
+     */
+    public LocalMaterialData rotate()
+    {
+    	return rotate(1);
+    }
+    
+    /**
+     * Gets a new material that is rotated 90 degrees. North -> west -> south ->
+     * east. If this material cannot be rotated, the material itself is
+     * returned.
+     * 
+     * @return The rotated material.
+     */
+    public abstract LocalMaterialData rotate(int rotateTimes);
+      
+	public LocalMaterialData parseWithBiomeAndHeight(boolean biomeConfigsHaveReplacement, ReplacedBlocksMatrix replaceBlocks, int y)
+	{	
+        if (!biomeConfigsHaveReplacement)
+        {
+            // Don't waste time here, ReplacedBlocks is empty everywhere
+            return this;
+        }
+        return replaceBlocks.replaceBlock(y, this);
+	}
 
-	public abstract boolean hasData();
+    public abstract boolean equals(Object other);
+    
+    public abstract int hashCode();
+    
+    public String toString()
+    {
+    	return getName();
+    }
 }

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterialTag.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterialTag.java
@@ -1,0 +1,14 @@
+package com.pg85.otg.util.materials;
+
+/**
+ * Represents one of Minecraft's material tags.
+ * Immutable.
+ */
+public abstract class LocalMaterialTag extends LocalMaterialBase
+{
+	@Override
+	public boolean isTag()
+	{
+		return true;
+	}
+}

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/MaterialSetEntry.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/MaterialSetEntry.java
@@ -2,13 +2,11 @@ package com.pg85.otg.util.materials;
 
 class MaterialSetEntry
 {
-    private LocalMaterialData material;
-    private final boolean includesBlockData;
+    private LocalMaterialBase material;
 
-    MaterialSetEntry(LocalMaterialData material, boolean includesBlockData)
+    MaterialSetEntry(LocalMaterialBase material)
     {
         this.material = material;
-        this.includesBlockData = includesBlockData;
     }
 
     @Override
@@ -33,28 +31,20 @@ class MaterialSetEntry
     @Override
     public int hashCode()
     {
-        //if (includesBlockData)
-        //{
-            return material.hashCode();
-        //} else
-        //{
-            //return material.hashCodeWithoutBlockData();
-        //}
+        return this.material.hashCode();
     }
-
-    /*
-    public void parseForWorld(WorldConfig worldConfig)
-    {
-    	material.parseForWorld(worldConfig);
-    }
-    */
 
     @Override
     public String toString()
     {
-        return material.toString();
+        return this.material.toString();
     }
 
+    public LocalMaterialBase getMaterial()
+    {
+    	return this.material;
+    }
+    
     /**
      * Rotates this check 90 degrees. If block data was ignored in this check,
      * it will still be ignored, otherwise the block data will be rotated too.
@@ -63,14 +53,12 @@ class MaterialSetEntry
      */
     MaterialSetEntry rotate()
     {
-        if (!includesBlockData)
+        if (this.material.isTag())
         {
-            // Don't rotate block data
-            return new MaterialSetEntry(material, false);
-        } else
-        {
-            // Actually rotate block data, to maintain check correctness
-            return new MaterialSetEntry(material.rotate(), true);
+            return new MaterialSetEntry(this.material);
+        } else {
+            // Rotate block data, to maintain check correctness
+            return new MaterialSetEntry(((LocalMaterialData)this.material).rotate());
         }
     }
 }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/biome/ForgeMojangSettings.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/biome/ForgeMojangSettings.java
@@ -75,12 +75,12 @@ public final class ForgeMojangSettings implements MojangSettings
 	@Override
 	public LocalMaterialData getSurfaceBlock()
 	{
-		return ForgeMaterialData.ofMinecraftBlockState(this.biomeBase.getGenerationSettings().getSurfaceBuilderConfig().getTopMaterial());
+		return ForgeMaterialData.ofBlockState(this.biomeBase.getGenerationSettings().getSurfaceBuilderConfig().getTopMaterial());
 	}
 
 	@Override
 	public LocalMaterialData getGroundBlock()
 	{
-		return ForgeMaterialData.ofMinecraftBlockState(this.biomeBase.getGenerationSettings().getSurfaceBuilderConfig().getUnderMaterial());
+		return ForgeMaterialData.ofBlockState(this.biomeBase.getGenerationSettings().getSurfaceBuilderConfig().getUnderMaterial());
 	}
 }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/commands/ExportCommand.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/commands/ExportCommand.java
@@ -139,7 +139,7 @@ public class ExportCommand
 			else
 			{
 				// Create a new BO3 from our settings
-				LocalMaterialData centerBlock = centerBlockState == null ? null : ForgeMaterialData.ofMinecraftBlockState(centerBlockState);
+				LocalMaterialData centerBlock = centerBlockState == null ? null : ForgeMaterialData.ofBlockState(centerBlockState);
 				bo3 = BO3Creator.create(lowCorner, highCorner, center, centerBlock, objectName, includeAir,
 					objectPath, otgRegion, nbtHelper, null, template.getSettings(), presetName,
 					OTG.getEngine().getOTGRootFolder(), OTG.getEngine().getPluginConfig().getSpawnLogEnabled(),

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeChunkBuffer.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeChunkBuffer.java
@@ -35,6 +35,6 @@ class ForgeChunkBuffer extends ChunkBuffer
 	@Override
 	public LocalMaterialData getBlock(int blockX, int blockY, int blockZ)
 	{
-		return ForgeMaterialData.ofMinecraftBlockState(this.chunk.getBlockState(this.mutable.set(blockX, blockY, blockZ)));
+		return ForgeMaterialData.ofBlockState(this.chunk.getBlockState(this.mutable.set(blockX, blockY, blockZ)));
 	}
 }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
@@ -309,7 +309,7 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 		// Get internal coordinates for block in chunk
 		int internalX = x & 0xF;
 		int internalZ = z & 0xF;
-		return ForgeMaterialData.ofMinecraftBlockState(chunk.getBlockState(new BlockPos(internalX, y, internalZ)));
+		return ForgeMaterialData.ofBlockState(chunk.getBlockState(new BlockPos(internalX, y, internalZ)));
 	}
 	
 	@Override
@@ -411,7 +411,7 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 		{
 			blockState = chunk.getBlockState(new BlockPos(internalX, i, internalZ));
 			block = blockState.getBlock();
-			material = ForgeMaterialData.ofMinecraftBlockState(blockState);
+			material = ForgeMaterialData.ofBlockState(blockState);
 			isLiquid = material.isLiquid();
 			isSolid =
 			(

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/OTGNoiseChunkGenerator.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/OTGNoiseChunkGenerator.java
@@ -389,7 +389,6 @@ public final class OTGNoiseChunkGenerator extends ChunkGenerator
 				}
 			}
 		}
-
 	}
 
 	// Mob spawning on initial chunk spawn (animals).
@@ -608,7 +607,7 @@ public final class OTGNoiseChunkGenerator extends ChunkGenerator
 			blockInChunk = chunk.getBlockState(new BlockPos(blockX, y, blockZ));
 			if (blockInChunk != null)
 			{
-				blocksInColumn[y] = ForgeMaterialData.ofMinecraftBlockState(blockInChunk);
+				blocksInColumn[y] = ForgeMaterialData.ofBlockState(blockInChunk);
 			} else {
 				break;
 			}

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialReader.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialReader.java
@@ -3,6 +3,7 @@ package com.pg85.otg.forge.materials;
 import com.pg85.otg.exception.InvalidConfigException;
 import com.pg85.otg.util.interfaces.IMaterialReader;
 import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterialTag;
 
 public class ForgeMaterialReader implements IMaterialReader
 {
@@ -10,5 +11,11 @@ public class ForgeMaterialReader implements IMaterialReader
 	public LocalMaterialData readMaterial(String string) throws InvalidConfigException
 	{
 		return ForgeMaterials.readMaterial(string);
+	}
+	
+	@Override
+	public LocalMaterialTag readTag(String string) throws InvalidConfigException
+	{
+		return ForgeMaterials.readTag(string);
 	}
 }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialTag.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialTag.java
@@ -1,0 +1,37 @@
+package com.pg85.otg.forge.materials;
+
+import com.pg85.otg.util.materials.LocalMaterialTag;
+
+import net.minecraft.block.Block;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ITag;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.ResourceLocationException;
+
+public class ForgeMaterialTag extends LocalMaterialTag
+{
+	public static LocalMaterialTag ofString(String name)
+	{
+		final ResourceLocation resourceLocation;
+		try
+		{		
+			resourceLocation = new ResourceLocation(name.trim().toLowerCase());			
+		} catch(ResourceLocationException ex) {
+			return null;
+		}
+		ITag<Block> blockTag = BlockTags.getWrappers().stream().filter(n -> n.getName().equals(resourceLocation)).findFirst().orElse(null);
+		return blockTag == null ? null : new ForgeMaterialTag(blockTag);
+	}
+	
+	private ITag<Block> blockTag;
+	
+	private ForgeMaterialTag(ITag<Block> blockTag)
+	{
+		this.blockTag = blockTag;
+	}
+
+	public ITag<Block> getTag()
+	{
+		return this.blockTag;
+	}
+}

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterials.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterials.java
@@ -5,6 +5,7 @@ import com.pg85.otg.exception.InvalidConfigException;
 import com.pg85.otg.logging.LogMarker;
 import com.pg85.otg.util.FifoMap;
 import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterialTag;
 import com.pg85.otg.util.materials.LocalMaterials;
 
 import net.minecraft.block.BambooBlock;
@@ -18,7 +19,9 @@ import net.minecraft.state.properties.DoubleBlockHalf;
 
 class ForgeMaterials extends LocalMaterials
 {
-	private static final FifoMap<String, LocalMaterialData> CachedMaterials = new FifoMap<String, LocalMaterialData>(4096); // TODO: Smaller cache should be ok, only most frequently used should be cached?
+	// TODO: Smaller caches should be ok, only most frequently used should be cached?
+	private static final FifoMap<String, LocalMaterialData> CachedMaterials = new FifoMap<String, LocalMaterialData>(4096); 
+	private static final FifoMap<String, LocalMaterialTag> CachedTags = new FifoMap<String, LocalMaterialTag>(4096);
 	
 	static
 	{
@@ -87,18 +90,18 @@ class ForgeMaterials extends LocalMaterials
 			LONG_GRASS = readMaterial(LocalMaterials.LONG_GRASS_NAME);
 			RED_MUSHROOM = readMaterial(LocalMaterials.RED_MUSHROOM_NAME);
 
-			DOUBLE_TALL_GRASS_LOWER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.DOUBLE_TALL_GRASS_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
-			DOUBLE_TALL_GRASS_UPPER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.DOUBLE_TALL_GRASS_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
-			LARGE_FERN_LOWER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LARGE_FERN_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
-			LARGE_FERN_UPPER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LARGE_FERN_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
-			LILAC_LOWER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LILAC_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
-			LILAC_UPPER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LILAC_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
-			PEONY_LOWER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.PEONY_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
-			PEONY_UPPER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.PEONY_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
-			ROSE_BUSH_LOWER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.ROSE_BUSH_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
-			ROSE_BUSH_UPPER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.ROSE_BUSH_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
-			SUNFLOWER_LOWER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.SUNFLOWER_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
-			SUNFLOWER_UPPER = ForgeMaterialData.ofMinecraftBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.SUNFLOWER_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
+			DOUBLE_TALL_GRASS_LOWER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.DOUBLE_TALL_GRASS_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
+			DOUBLE_TALL_GRASS_UPPER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.DOUBLE_TALL_GRASS_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
+			LARGE_FERN_LOWER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LARGE_FERN_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
+			LARGE_FERN_UPPER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LARGE_FERN_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
+			LILAC_LOWER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LILAC_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
+			LILAC_UPPER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.LILAC_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
+			PEONY_LOWER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.PEONY_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
+			PEONY_UPPER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.PEONY_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
+			ROSE_BUSH_LOWER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.ROSE_BUSH_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
+			ROSE_BUSH_UPPER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.ROSE_BUSH_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
+			SUNFLOWER_LOWER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.SUNFLOWER_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER));
+			SUNFLOWER_UPPER = ForgeMaterialData.ofBlockState(((ForgeMaterialData)readMaterial(LocalMaterials.SUNFLOWER_NAME)).internalBlock().setValue(DoublePlantBlock.HALF, DoubleBlockHalf.UPPER));
 			
 			PUMPKIN = readMaterial(LocalMaterials.PUMPKIN_NAME);
 			CACTUS = readMaterial(LocalMaterials.CACTUS_NAME);
@@ -108,21 +111,21 @@ class ForgeMaterials extends LocalMaterials
 			WATER_LILY = readMaterial(LocalMaterials.WATER_LILY_NAME);
 			SUGAR_CANE_BLOCK = readMaterial(LocalMaterials.SUGAR_CANE_BLOCK_NAME);
 			BlockState bambooState = Blocks.BAMBOO.defaultBlockState().setValue(BambooBlock.AGE, 1).setValue(BambooBlock.LEAVES, BambooLeaves.NONE).setValue(BambooBlock.STAGE, 0);
-			BAMBOO = ForgeMaterialData.ofMinecraftBlockState(bambooState);
-			BAMBOO_SMALL = ForgeMaterialData.ofMinecraftBlockState(bambooState.setValue(BambooBlock.LEAVES, BambooLeaves.SMALL));
-			BAMBOO_LARGE = ForgeMaterialData.ofMinecraftBlockState(bambooState.setValue(BambooBlock.LEAVES, BambooLeaves.LARGE));
-			BAMBOO_LARGE_GROWING = ForgeMaterialData.ofMinecraftBlockState(bambooState.setValue(BambooBlock.LEAVES, BambooLeaves.LARGE).setValue(BambooBlock.STAGE, 1));
+			BAMBOO = ForgeMaterialData.ofBlockState(bambooState);
+			BAMBOO_SMALL = ForgeMaterialData.ofBlockState(bambooState.setValue(BambooBlock.LEAVES, BambooLeaves.SMALL));
+			BAMBOO_LARGE = ForgeMaterialData.ofBlockState(bambooState.setValue(BambooBlock.LEAVES, BambooLeaves.LARGE));
+			BAMBOO_LARGE_GROWING = ForgeMaterialData.ofBlockState(bambooState.setValue(BambooBlock.LEAVES, BambooLeaves.LARGE).setValue(BambooBlock.STAGE, 1));
 			PODZOL = readMaterial(LocalMaterials.PODZOL_NAME);
-			SEAGRASS = ForgeMaterialData.ofMinecraftBlockState(Blocks.SEAGRASS.defaultBlockState());
-			TALL_SEAGRASS_LOWER = ForgeMaterialData.ofMinecraftBlockState(Blocks.TALL_SEAGRASS.defaultBlockState().setValue(TallSeaGrassBlock.HALF, DoubleBlockHalf.LOWER));
-			TALL_SEAGRASS_UPPER = ForgeMaterialData.ofMinecraftBlockState(Blocks.TALL_SEAGRASS.defaultBlockState().setValue(TallSeaGrassBlock.HALF, DoubleBlockHalf.UPPER));
-			KELP = ForgeMaterialData.ofMinecraftBlockState(Blocks.KELP.defaultBlockState());
-			KELP_PLANT = ForgeMaterialData.ofMinecraftBlockState(Blocks.KELP_PLANT.defaultBlockState());
-			VINE_SOUTH = ForgeMaterialData.ofMinecraftBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.SOUTH, true));
-			VINE_NORTH = ForgeMaterialData.ofMinecraftBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.NORTH, true));
-			VINE_WEST = ForgeMaterialData.ofMinecraftBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.WEST, true));
-			VINE_EAST = ForgeMaterialData.ofMinecraftBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.EAST, true));
-			SEA_PICKLE = ForgeMaterialData.ofMinecraftBlockState(Blocks.SEA_PICKLE.defaultBlockState());
+			SEAGRASS = ForgeMaterialData.ofBlockState(Blocks.SEAGRASS.defaultBlockState());
+			TALL_SEAGRASS_LOWER = ForgeMaterialData.ofBlockState(Blocks.TALL_SEAGRASS.defaultBlockState().setValue(TallSeaGrassBlock.HALF, DoubleBlockHalf.LOWER));
+			TALL_SEAGRASS_UPPER = ForgeMaterialData.ofBlockState(Blocks.TALL_SEAGRASS.defaultBlockState().setValue(TallSeaGrassBlock.HALF, DoubleBlockHalf.UPPER));
+			KELP = ForgeMaterialData.ofBlockState(Blocks.KELP.defaultBlockState());
+			KELP_PLANT = ForgeMaterialData.ofBlockState(Blocks.KELP_PLANT.defaultBlockState());
+			VINE_SOUTH = ForgeMaterialData.ofBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.SOUTH, true));
+			VINE_NORTH = ForgeMaterialData.ofBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.NORTH, true));
+			VINE_WEST = ForgeMaterialData.ofBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.WEST, true));
+			VINE_EAST = ForgeMaterialData.ofBlockState(Blocks.VINE.defaultBlockState().setValue(VineBlock.EAST, true));
+			SEA_PICKLE = ForgeMaterialData.ofBlockState(Blocks.SEA_PICKLE.defaultBlockState());
 
 			// Ores
 			COAL_ORE = readMaterial(LocalMaterials.COAL_ORE_NAME);
@@ -166,7 +169,7 @@ class ForgeMaterials extends LocalMaterials
 		{
 			throw new InvalidConfigException("Cannot read block: " + name);
 		}
-		
+
 		try
 		{
 			material = ForgeMaterialData.ofString(name);
@@ -180,5 +183,23 @@ class ForgeMaterials extends LocalMaterials
 		CachedMaterials.put(name, material);
 		
 		return material;
+	}
+	
+	static LocalMaterialTag readTag(String name) throws InvalidConfigException
+	{
+		if(name == null)
+		{
+			return null;
+		}
+		
+		LocalMaterialTag tag = CachedTags.get(name);
+		if(tag != null)
+		{
+			return tag;
+		}
+
+		tag = ForgeMaterialTag.ofString(name);
+		CachedTags.put(name, tag);
+		return tag;
 	}
 }

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterialData.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterialData.java
@@ -132,17 +132,20 @@ public class SpigotMaterialData extends LocalMaterialData
 		// Try without data
 		Block block;
 
-		// This returns AIR if block is not found ><. ----Does it for spigot too?
-		block = IRegistry.BLOCK.get(new MinecraftKey(blockNameCorrected));
-		if (block != Blocks.AIR || blockNameCorrected.toLowerCase().endsWith("air"))
+		try
 		{
-			// For leaves, add DISTANCE 1 to make them not decay.
-			if (block.getBlockData().getMaterial().equals(Material.LEAVES))
+			// This returns AIR if block is not found ><. ----Does it for spigot too?
+			block = IRegistry.BLOCK.get(new MinecraftKey(blockNameCorrected));
+			if (block != Blocks.AIR || blockNameCorrected.toLowerCase().endsWith("air"))
 			{
-				return ofBlockData(block.getBlockData().set(BlockLeaves.DISTANCE, 1), input);
+				// For leaves, add DISTANCE 1 to make them not decay.
+				if (block.getBlockData().getMaterial().equals(Material.LEAVES))
+				{
+					return ofBlockData(block.getBlockData().set(BlockLeaves.DISTANCE, 1), input);
+				}
+				return ofBlockData(block.getBlockData(), input);
 			}
-			return ofBlockData(block.getBlockData(), input);
-		}
+		} catch(ResourceKeyInvalidException ignored) { }
 
 		// Try legacy name again, without data.
 		blockState = SpigotLegacyMaterials.fromLegacyBlockName(blockNameCorrected.replace("minecraft:", ""));

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterialReader.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterialReader.java
@@ -3,6 +3,7 @@ package com.pg85.otg.spigot.materials;
 import com.pg85.otg.exception.InvalidConfigException;
 import com.pg85.otg.util.interfaces.IMaterialReader;
 import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterialTag;
 
 public class SpigotMaterialReader implements IMaterialReader
 {
@@ -14,5 +15,11 @@ public class SpigotMaterialReader implements IMaterialReader
 		//LocalMaterialData tmp = ;
 		//OTG.log(LogMarker.TRACE, "Result: " + (tmp == null ? "null" : tmp.toString()));
 		return SpigotMaterials.readMaterial(string);
+	}
+
+	@Override
+	public LocalMaterialTag readTag(String string) throws InvalidConfigException
+	{
+		return SpigotMaterials.readTag(string);
 	}
 }

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterialTag.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterialTag.java
@@ -1,0 +1,37 @@
+package com.pg85.otg.spigot.materials;
+
+import com.pg85.otg.util.materials.LocalMaterialTag;
+
+import net.minecraft.server.v1_16_R3.Block;
+import net.minecraft.server.v1_16_R3.MinecraftKey;
+import net.minecraft.server.v1_16_R3.Tag;
+import net.minecraft.server.v1_16_R3.TagsBlock;
+
+public class SpigotMaterialTag extends LocalMaterialTag
+{
+	public static LocalMaterialTag ofString(String name)
+	{
+		final MinecraftKey resourceLocation;
+		try
+		{		
+			resourceLocation = new MinecraftKey(name.trim().toLowerCase());			
+		} catch(Exception ex) {
+			// TODO: Find out which exception spigot throws when resourcelocation can't be parsed.
+			return null;
+		}
+		Tag<Block> blockTag = TagsBlock.b().stream().filter(n -> n.a().equals(resourceLocation)).findFirst().orElse(null);
+		return blockTag == null ? null : new SpigotMaterialTag(blockTag);
+	}
+	
+	private Tag<Block> blockTag;
+	
+	private SpigotMaterialTag(Tag<Block> blockTag)
+	{
+		this.blockTag = blockTag;
+	}
+
+	public Tag<Block> getTag()
+	{
+		return this.blockTag;
+	}
+}

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterials.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterials.java
@@ -5,6 +5,7 @@ import com.pg85.otg.exception.InvalidConfigException;
 import com.pg85.otg.logging.LogMarker;
 import com.pg85.otg.util.FifoMap;
 import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterialTag;
 import com.pg85.otg.util.materials.LocalMaterials;
 import net.minecraft.server.v1_16_R3.BlockBamboo;
 import net.minecraft.server.v1_16_R3.BlockPropertyBambooSize;
@@ -17,7 +18,9 @@ import net.minecraft.server.v1_16_R3.IBlockData;
 
 public class SpigotMaterials extends LocalMaterials
 {
-	private static final FifoMap<String, LocalMaterialData> CachedMaterials = new FifoMap<>(4096); // TODO: Smaller cache should be ok, only most frequently used should be cached?
+	// TODO: Smaller cache should be ok, only most frequently used should be cached?
+	private static final FifoMap<String, LocalMaterialData> CachedMaterials = new FifoMap<>(4096);
+	private static final FifoMap<String, LocalMaterialTag> CachedTags = new FifoMap<>(4096);
 
 	static
 	{
@@ -183,5 +186,23 @@ public class SpigotMaterials extends LocalMaterials
 		CachedMaterials.put(name, material);
 
 		return material;
+	}
+	
+	static LocalMaterialTag readTag(String name) throws InvalidConfigException
+	{
+		if(name == null)
+		{
+			return null;
+		}
+		
+		LocalMaterialTag tag = CachedTags.get(name);
+		if(tag != null)
+		{
+			return tag;
+		}
+
+		tag = SpigotMaterialTag.ofString(name);
+		CachedTags.put(name, tag);	
+		return tag;
 	}
 }


### PR DESCRIPTION
- ReplaceBlocks and MaterialSet settings (any setting or resource that has a "target" block) accept BlockTags, this replaces the old targeting logic based on block data, where SAND would match all SAND:X. Input for target blocks is first parsed as a BlockTag, if no matching BlockTag is found, it's parsed as a block.

* Blocks can have any number of block tags, assigned by default and/or via datapacks. BlockTags for the default blocks don't exactly match 1.12.2 block variants, so some things (like hard clay) cannot be targeted as a group like before.