### PR TITLE
1.16.5 - 0.0.12:  Spigot bands of resources fix, version number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ defaultTasks 'clean', 'build', 'createReleaseJar', 'install'
 
 allprojects
 {
-    version = "1.16.5-0.0.11"
+    version = "1.16.5-0.0.12"
     group = "com.pg85.otg"
 
     // Version of the shadow plugin

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/OTGNoiseChunkGenerator.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/OTGNoiseChunkGenerator.java
@@ -1,7 +1,6 @@
 package com.pg85.otg.forge.gen;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
@@ -83,7 +82,6 @@ import net.minecraft.world.gen.settings.NoiseSettings;
 import net.minecraft.world.gen.settings.StructureSeparationSettings;
 import net.minecraft.world.spawner.WorldEntitySpawner;
 import net.minecraft.world.storage.FolderName;
-import net.minecraft.world.storage.IServerWorldInfo;
 
 public final class OTGNoiseChunkGenerator extends ChunkGenerator
 {

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/SpigotWorldGenRegion.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/SpigotWorldGenRegion.java
@@ -112,7 +112,7 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 	@Override
 	public IBiomeConfig getBiomeConfigForPopulation (int worldX, int worldZ, ChunkCoordinate chunkBeingPopulated)
 	{
-		return getBiomeForPopulation(worldX, worldX, chunkBeingPopulated).getBiomeConfig();
+		return getBiomeForPopulation(worldX, worldZ, chunkBeingPopulated).getBiomeConfig();
 	}
 
 	@Override
@@ -479,9 +479,7 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 					if (chunkBeingPopulated == null)
 					{
 						replaceBlocksMatrix = this.getBiomeConfig(x, z).getReplaceBlocks();
-					}
-					else
-					{
+					} else {
 						replaceBlocksMatrix = this.getBiomeConfigForPopulation(x, z, chunkBeingPopulated).getReplaceBlocks();
 					}
 				}


### PR DESCRIPTION
- Fixed "bands of resources" problem for spigot, where bo4's/smoothing areas/replaceblocks/freezing used the wrong biomes and placed the wrong blocks.