### PR TITLE
1.16.4 dev pg

### DIFF
--- a/common/common-util/src/main/java/com/pg85/otg/util/BlockPos2D.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/BlockPos2D.java
@@ -2,8 +2,8 @@ package com.pg85.otg.util;
 
 public class BlockPos2D
 {
-	private final int x;
-	private final int z;
+	public final int x;
+	public final int z;
 	
 	public BlockPos2D(int x, int z)
 	{

--- a/common/common-util/src/main/java/com/pg85/otg/util/gen/ChunkBuffer.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/gen/ChunkBuffer.java
@@ -43,6 +43,8 @@ public abstract class ChunkBuffer
      */
     public abstract LocalMaterialData getBlock(int blockX, int blockY, int blockZ);
 
+    // TODO: Are these really necessary, can use heightmaps?
+    
     private final short[] highestBlockHeight = new short[ChunkCoordinate.CHUNK_SIZE * ChunkCoordinate.CHUNK_SIZE];
 	public int getHighestBlockForColumn(int blockX, int blockZ)
 	{

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/MaterialSet.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/MaterialSet.java
@@ -96,6 +96,7 @@ public class MaterialSet
     @Override
     public int hashCode()
     {
+    	// TODO: This method is never called, remove?
         final int prime = 31;
         int result = 1;
         result = prime * result + (this.allMaterials ? 1231 : 1237);
@@ -109,6 +110,7 @@ public class MaterialSet
     @Override
     public boolean equals(Object obj)
     {
+    	// TODO: This method is never called, remove?
         if (this == obj)
         {
             return true;

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/commands/MapCommand.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/commands/MapCommand.java
@@ -1,53 +1,56 @@
 package com.pg85.otg.forge.commands;
 
 import com.pg85.otg.forge.biome.OTGBiomeProvider;
+import com.pg85.otg.forge.gen.ForgeChunkBuffer;
+import com.pg85.otg.forge.gen.OTGNoiseChunkGenerator;
+import com.pg85.otg.forge.materials.ForgeMaterialData;
+import com.pg85.otg.util.BlockPos2D;
+import com.pg85.otg.util.ChunkCoordinate;
+import com.pg85.otg.util.materials.LocalMaterials;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.command.CommandSource;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.StringTextComponent;
 
 import javax.imageio.ImageIO;
+
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 public class MapCommand
 {
-	protected static int mapBiomes(CommandSource source, int width, int height)
+	private static final Object queueLock = new Object();
+	private static final Object imgLock = new Object();
+	
+	protected static int mapBiomes(CommandSource source, int width, int height, int threads)
 	{
-		if (!(source.getLevel().getChunkSource().generator.getBiomeSource() instanceof OTGBiomeProvider))
+		if (
+			!(source.getLevel().getChunkSource().generator instanceof OTGNoiseChunkGenerator) || 
+			!(source.getLevel().getChunkSource().generator.getBiomeSource() instanceof OTGBiomeProvider)
+		)
 		{
 			source.sendSuccess(new StringTextComponent("Please run this command in an OTG world."), false);
 			return 1;
 		}
-
-		OTGBiomeProvider provider = (OTGBiomeProvider) source.getLevel().getChunkSource().generator.getBiomeSource();
-
-		//setup image
-
+		
 		BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-
-		int progressUpdate = img.getHeight() / 8;
-
-		for (int x = 0; x < img.getHeight(); x++)
-		{
-			for (int z = 0; z < img.getWidth(); z++)
-			{
-				//set the color
-				img.setRGB(x, z, provider.configLookup[provider.getSampler().sample(x, z)].getBiomeColor());
-			}
-
-			//send a progress update to let people know the server isn't dying
-			if (x % progressUpdate == 0)
-			{
-				source.sendSuccess(new StringTextComponent((((double) x / img.getHeight()) * 100) + "% Done mapping"), true);
-			}
-		}
-
-		String fileName = source.getServer().getWorldData().getLevelName() + " biomes.png";
-
-		source.sendSuccess(new StringTextComponent("Finished mapping! The resulting image is located at " + fileName + "."), true);
-
-		//save the biome map
+		
+		Instant start = Instant.now();	
+		handleArea(width, height, img, source, (OTGNoiseChunkGenerator)source.getLevel().getChunkSource().generator, (OTGBiomeProvider) source.getLevel().getChunkSource().generator.getBiomeSource(), true, threads);
+		Instant finish = Instant.now();
+		Duration duration = Duration.between(start, finish); // Note: This is probably the least helpful time duration helper class I've ever seen ...
+		
+		String fileName = source.getServer().getWorldData().getLevelName() + " biomes.png";        
 		Path p = Paths.get(fileName);
 		try
 		{
@@ -58,6 +61,238 @@ public class MapCommand
 			e.printStackTrace();
 		}
 
+		source.sendSuccess(new StringTextComponent("Finished mapping in " + (duration.toHours() > 9 ? duration.toHours() : "0" + duration.toHours()) + ":" + (duration.toMinutes() % 60 > 9 ? (duration.toMinutes() % 60) : "0" + (duration.toMinutes() % 60)) + ":" + (duration.get(ChronoUnit.SECONDS) % 60 > 9 ? (duration.get(ChronoUnit.SECONDS) % 60) : "0" + (duration.get(ChronoUnit.SECONDS) % 60)) + "! The resulting image is located at " + fileName + "."), true);
+		
 		return 0;
+	}
+	
+	static int mapTerrain(CommandSource source, int width, int height, int threads)
+	{
+		if (
+			!(source.getLevel().getChunkSource().generator instanceof OTGNoiseChunkGenerator) || 
+			!(source.getLevel().getChunkSource().generator.getBiomeSource() instanceof OTGBiomeProvider)
+		)
+		{
+			source.sendSuccess(new StringTextComponent("Please run this command in an OTG world."), false);
+			return 1;
+		}
+		
+		BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+		
+		Instant start = Instant.now();
+		handleArea(width, height, img, source, (OTGNoiseChunkGenerator)source.getLevel().getChunkSource().generator, (OTGBiomeProvider) source.getLevel().getChunkSource().generator.getBiomeSource(), false, threads);
+		Instant finish = Instant.now();
+		Duration duration = Duration.between(start, finish);		
+		
+		String fileName = source.getServer().getWorldData().getLevelName() + " terrain.png";        
+		Path p = Paths.get(fileName);
+		try
+		{
+			ImageIO.write(img, "png", p.toAbsolutePath().toFile());
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+
+		source.sendSuccess(new StringTextComponent("Finished mapping in " + (duration.toHours() > 9 ? duration.toHours() : "0" + duration.toHours()) + ":" + (duration.toMinutes() % 60 > 9 ? (duration.toMinutes() % 60) : "0" + (duration.toMinutes() % 60)) + ":" + (duration.get(ChronoUnit.SECONDS) % 60 > 9 ? (duration.get(ChronoUnit.SECONDS) % 60) : "0" + (duration.get(ChronoUnit.SECONDS) % 60)) + "! The resulting image is located at " + fileName + "."), true);
+		
+		return 0;
+	}
+	
+	static void handleArea(int width, int height, BufferedImage img, CommandSource source, OTGNoiseChunkGenerator generator, OTGBiomeProvider provider, boolean mapBiomes, int threads)
+	{
+        List<BlockPos2D> coordsToHandle = new ArrayList<BlockPos2D>(width * height);
+		for (int chunkX = 0; chunkX < (int)Math.ceil(height / 16f); chunkX++)
+		{
+			for (int chunkZ = 0; chunkZ < (int)Math.ceil(width / 16f); chunkZ++)
+			{
+				coordsToHandle.add(new BlockPos2D(chunkX, chunkZ));
+			}
+		}	
+
+        int maxConcurrent = threads;
+        CountDownLatch latch = new CountDownLatch(maxConcurrent);
+        MapCommand outer = new MapCommand();
+        int totalSize = coordsToHandle.size();
+		for(int i = 0; i < maxConcurrent; i++)
+		{
+			outer.new Worker(latch, source, generator, provider, img, coordsToHandle, totalSize, mapBiomes, width, height).start();
+		}
+		
+        try {
+        	latch.await();
+    	} catch (InterruptedException e) {
+        	e.printStackTrace();
+		}
+	}
+	
+	static int shadeColor(int rgbColor, int percent)
+	{
+		int red = (rgbColor >> 16) & 0xFF;
+		int green = (rgbColor >> 8) & 0xFF;
+		int blue = rgbColor & 0xFF;
+		
+		red = red * percent / 100;
+		red = red > 255 ? 255 : red;
+		green = green * percent / 100;
+		green = green > 255 ? 255 : green;
+		blue = blue * percent / 100;
+		blue = blue > 255 ? 255 : blue;
+
+	    return 65536 * red + 256 * green + blue;
+	}
+	
+	public class Worker implements Runnable
+	{
+		private Thread runner;		
+		private final int totalSize;
+		private final List<BlockPos2D> coordsToHandle;
+	    private final CountDownLatch latch;
+	    private final OTGNoiseChunkGenerator generator;
+	    private final OTGBiomeProvider provider;
+	    private final CommandSource source;
+	    private final BufferedImage img;
+	    private final int progressUpdate;
+	    private final boolean mapBiomes;
+	    private final int width;
+	    private final int height;
+
+	    public Worker(CountDownLatch latch, CommandSource source, OTGNoiseChunkGenerator generator, OTGBiomeProvider provider, BufferedImage img, List<BlockPos2D> coordsToHandle, int totalSize, boolean mapBiomes, int width, int height)
+	    {
+	        this.latch = latch;
+	        this.generator = generator;
+	        this.provider = provider;
+	        this.source = source;
+	        this.img = img;
+	        this.progressUpdate = (int)Math.floor(totalSize / 100f);
+	        this.coordsToHandle = coordsToHandle;
+	        this.totalSize = totalSize;
+	        this.mapBiomes = mapBiomes;
+	        this.width = width;
+	        this.height = height;
+	    }
+
+	    public void start()
+	    {
+	        this.runner = new Thread(this);
+	        this.runner.start();
+	    }
+	    
+	    @Override
+	    public void run()
+	    {
+			//set the color
+	    	while(true)
+	    	{
+	    		BlockPos2D coords = null;
+	    		int sizeLeft;
+	    		synchronized(queueLock)
+	    		{
+	    			sizeLeft = coordsToHandle.size();
+	    			if(sizeLeft > 0)
+	    			{
+	    				coords = coordsToHandle.remove(sizeLeft - 1);
+	    			}
+	    		}
+    			// Send a progress update to let people know the server isn't dying
+    			if (sizeLeft % progressUpdate == 0)
+    			{
+    				source.sendSuccess(new StringTextComponent((int)Math.floor(100 - (((double)sizeLeft / totalSize) * 100)) + "% Done mapping"), true);
+    			}
+	    		
+	    		if(coords != null)
+	    		{
+	    			if(mapBiomes)
+	    			{
+	    				getBiomePixel(coords);
+	    			} else {
+	    				getTerrainPixel(coords);
+	    			}
+	    		} else {
+    				latch.countDown();
+    				return;
+	    		}
+	    	}
+	    }
+
+	    private void getBiomePixel(BlockPos2D chunkCoords)
+	    {		
+			for (int internalX = 0; internalX < 16; internalX++)
+			{
+				for (int internalZ = 0; internalZ < 16; internalZ++)
+				{
+					int x = chunkCoords.x * 16 + internalX;
+					int z = chunkCoords.z * 16 + internalZ;
+					if(x <= width && z <= height)
+					{
+						synchronized(imgLock)
+						{
+							img.setRGB(x, z, provider.configLookup[provider.getSampler().sample(x, z)].getBiomeColor());
+						}
+					}
+				}
+			}
+	    }
+	    
+	    private void getTerrainPixel(BlockPos2D chunkCoords)
+	    {
+	    	ForgeChunkBuffer chunk = generator.getChunkWithoutLoadingOrCaching(source.getLevel().getRandom(), ChunkCoordinate.fromChunkCoords(chunkCoords.x, chunkCoords.z));
+			for (int internalX = 0; internalX < 16; internalX++)
+			{
+				for (int internalZ = 0; internalZ < 16; internalZ++)
+				{
+					int x = chunkCoords.x * 16 + internalX;
+					int z = chunkCoords.z * 16 + internalZ;
+					if(x <= width && z <= height)
+					{
+						HighestBlockInfo highestBlockInfo = getHighestBlockInfoInUnloadedChunk(chunk, internalX, internalZ);
+
+						//int worldHeight = 255;
+						//int worldWaterLevel = 63;
+						//int min = worldWaterLevel - worldHeight;
+						//int max = worldWaterLevel + worldHeight;
+						int min = 0;
+						int max = 255;
+						int range = max - min;
+						int distance = -min + highestBlockInfo.y;
+						float relativeDistance = (float)distance / (float)range;
+						int shadePercentage = (int)Math.floor(relativeDistance * 2 * 100);
+						int rgbColor = shadeColor(highestBlockInfo.material.internalBlock().getBlock().defaultMaterialColor().col, shadePercentage);
+						synchronized(imgLock)
+						{
+							img.setRGB(x, z, rgbColor);
+						}
+					}
+				}
+			}	    	
+	    }
+
+		private HighestBlockInfo getHighestBlockInfoInUnloadedChunk(ForgeChunkBuffer chunk, int internalX, int internalZ)
+		{
+			// TODO: Just use heightmaps?
+			BlockState blockInChunk;
+			for (int y = chunk.getHighestBlockForColumn(internalX, internalZ); y >= 0; y--)
+			{
+				blockInChunk = chunk.getChunk().getBlockState(new BlockPos(internalX, y, internalZ));
+				if (blockInChunk != null && blockInChunk.getBlock() != Blocks.AIR)
+				{
+					return new HighestBlockInfo((ForgeMaterialData)ForgeMaterialData.ofBlockState(blockInChunk), y);					
+				}
+			}
+			return new HighestBlockInfo((ForgeMaterialData)LocalMaterials.AIR, 63);
+		}
+	}
+		
+	public class HighestBlockInfo
+	{
+		public final ForgeMaterialData material;
+		public final int y;
+		
+		public HighestBlockInfo(ForgeMaterialData material, int y)
+		{
+			this.material = material;
+			this.y = y;
+		}
 	}
 }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/commands/OTGCommand.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/commands/OTGCommand.java
@@ -38,16 +38,32 @@ public class OTGCommand
 					(context) -> HelpCommand.showHelp(context.getSource())
 				)
 			).then(
-				Commands.literal("map").executes(
-					(context) -> MapCommand.mapBiomes(context.getSource(), 2048, 2048)
+				Commands.literal("mapbiomes").executes(
+					(context) -> MapCommand.mapBiomes(context.getSource(), 2048, 2048, 1)
 				).then(
 					Commands.argument("width", IntegerArgumentType.integer(0)).executes(
-						(context) -> MapCommand.mapBiomes(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "width"))
+						(context) -> MapCommand.mapBiomes(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "width"), 1)
 					).then(
 						Commands.argument("height", IntegerArgumentType.integer(0)).executes(
-							(context) -> MapCommand.mapBiomes(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "height"))
-						)))
+							(context) -> MapCommand.mapBiomes(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "height"), 1)
+						).then(
+							Commands.argument("threads", IntegerArgumentType.integer(0)).executes(
+								(context) -> MapCommand.mapBiomes(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "height"), IntegerArgumentType.getInteger(context, "threads"))
+							))))
 			).then(
+				Commands.literal("mapterrain").executes(
+						(context) -> MapCommand.mapTerrain(context.getSource(), 2048, 2048, 1)
+					).then(
+						Commands.argument("width", IntegerArgumentType.integer(0)).executes(
+							(context) -> MapCommand.mapTerrain(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "width"), 1)
+						).then(
+							Commands.argument("height", IntegerArgumentType.integer(0)).executes(
+								(context) -> MapCommand.mapTerrain(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "height"), 1)
+							).then(
+								Commands.argument("threads", IntegerArgumentType.integer(0)).executes(
+									(context) -> MapCommand.mapTerrain(context.getSource(), IntegerArgumentType.getInteger(context, "width"), IntegerArgumentType.getInteger(context, "height"), IntegerArgumentType.getInteger(context, "threads"))
+								))))
+			).then(					
 				Commands.literal("data").then(
 					Commands.argument("type", StringArgumentType.word()).executes(
 						(context -> DataCommand.execute(context.getSource(), context.getArgument("type", String.class)))

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeChunkBuffer.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeChunkBuffer.java
@@ -8,8 +8,9 @@ import com.pg85.otg.util.materials.LocalMaterialData;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.ChunkPrimer;
+import net.minecraft.world.chunk.IChunk;
 
-class ForgeChunkBuffer extends ChunkBuffer
+public class ForgeChunkBuffer extends ChunkBuffer
 {
 	private final BlockPos.Mutable mutable = new BlockPos.Mutable();
 	private final ChunkPrimer chunk;
@@ -36,5 +37,10 @@ class ForgeChunkBuffer extends ChunkBuffer
 	public LocalMaterialData getBlock(int blockX, int blockY, int blockZ)
 	{
 		return ForgeMaterialData.ofBlockState(this.chunk.getBlockState(this.mutable.set(blockX, blockY, blockZ)));
+	}
+	
+	public IChunk getChunk()
+	{
+		return this.chunk;
 	}
 }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
@@ -297,7 +297,7 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 			)
 			{
 				// Calculate the material without loading the chunk.
-				return ((OTGNoiseChunkGenerator) this.chunkGenerator).getMaterialInUnloadedChunk(this, x , y, z);
+				return ((OTGNoiseChunkGenerator) this.chunkGenerator).getMaterialInUnloadedChunk(this.getWorldRandom(), x , y, z);
 			}
 		}
 		
@@ -375,7 +375,7 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 			)
 			{
 				// Calculate the material without loading the chunk.
-				return ((OTGNoiseChunkGenerator) this.chunkGenerator).getHighestBlockYInUnloadedChunk(this, x, z, findSolid, findLiquid, ignoreLiquid, ignoreSnow);
+				return ((OTGNoiseChunkGenerator) this.chunkGenerator).getHighestBlockYInUnloadedChunk(this.getWorldRandom(), x, z, findSolid, findLiquid, ignoreLiquid, ignoreSnow);
 			}
 		}
 		

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
@@ -317,32 +317,36 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 	public int getBlockAboveLiquidHeight(int x, int z, ChunkCoordinate chunkBeingPopulated)
 	{
 		int highestY = getHighestBlockYAt(x, z, false, true, false, false, false, chunkBeingPopulated);
-		if(highestY > 0)
+		if(highestY >= 0)
 		{
-			highestY += 1;
+			return highestY + 1;
 		} else {
-			highestY = -1;
+			return -1;
 		}
-		return highestY;
 	}
 
 	@Override
 	public int getBlockAboveSolidHeight(int x, int z, ChunkCoordinate chunkBeingPopulated)
 	{
 		int highestY = getHighestBlockYAt(x, z, true, false, true, true, false, chunkBeingPopulated);
-		if(highestY > 0)
+		if(highestY >= 0)
 		{
-			highestY += 1;
+			return highestY + 1;
 		} else {
-			highestY = -1;
+			return -1;
 		}
-		return highestY;
 	}
 
 	@Override
 	public int getHighestBlockAboveYAt(int x, int z, ChunkCoordinate chunkBeingPopulated)
 	{
-		return getHighestBlockYAt(x, z, true, true, false, false, false, chunkBeingPopulated) + 1;
+		int highestY = getHighestBlockYAt(x, z, true, true, false, false, false, chunkBeingPopulated);
+		if(highestY >= 0)
+		{
+			return highestY + 1;
+		} else {
+			return -1;
+		}
 	}
 
 	@Override

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeLegacyMaterials.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeLegacyMaterials.java
@@ -142,38 +142,38 @@ class ForgeLegacyMaterials
 				
 			case "wood_stairs":
 			case "oak_stairs":
-				return Blocks.OAK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.OAK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "birch_wood_stairs":
 			case "birch_stairs":
-				return Blocks.BIRCH_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.BIRCH_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "spruce_wood_stairs":
 			case "spruce_stairs":
-				return Blocks.SPRUCE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.SPRUCE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "jungle_wood_stairs":				
 			case "jungle_stairs":
-				return Blocks.JUNGLE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.JUNGLE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "cobblestone_stairs":
 			case "stone_stairs":
-				return Blocks.COBBLESTONE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
-			case "brick_stairs":
-				return Blocks.BRICK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.COBBLESTONE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "nether_brick_stairs":
-				return Blocks.NETHER_BRICK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.NETHER_BRICK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "sandstone_stairs":
-				return Blocks.SANDSTONE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.SANDSTONE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "quartz_stairs":
-				return Blocks.QUARTZ_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.QUARTZ_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "acacia_stairs":
-				return Blocks.ACACIA_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.ACACIA_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "dark_oak_stairs":
-				return Blocks.DARK_OAK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.DARK_OAK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "red_sandstone_stairs":
-				return Blocks.RED_SANDSTONE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.RED_SANDSTONE_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			case "purpur_stairs":
-				return Blocks.PURPUR_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.PURPUR_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
+			case "brick_stairs":
+				return Blocks.BRICK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);				
 			case "stone_brick_stairs":
 			case "smooth_stairs":
-				return Blocks.STONE_BRICK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.EAST);
+				return Blocks.STONE_BRICK_STAIRS.defaultBlockState().setValue(StairsBlock.FACING, Direction.NORTH);
 			
 			case "quartz_ore":
 				return Blocks.NETHER_QUARTZ_ORE.defaultBlockState();
@@ -1158,7 +1158,6 @@ class ForgeLegacyMaterials
 				case "stone_stairs":
 					return getStairsWithData(4, data);
 				case "brick_stairs":
-				case "smooth_stairs":					
 					return getStairsWithData(5, data);
 				case "nether_brick_stairs":
 					return getStairsWithData(7, data);
@@ -1175,6 +1174,7 @@ class ForgeLegacyMaterials
 				case "purpur_stairs":
 					return getStairsWithData(13, data);
 				case "stone_brick_stairs":
+				case "smooth_stairs":
 					return getStairsWithData(14, data);					
 				case "lever":
 					return getLeverOrButtonWithData(0, data);

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialData.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialData.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 public class ForgeMaterialData extends LocalMaterialData
 {
 	private static final LocalMaterialData blank = new ForgeMaterialData(null, null, true);
-	private static final HashMap<BlockState, LocalMaterialData> stateToMaterialDataMap = new HashMap<>();
+	private static final HashMap<BlockState, ForgeMaterialData> stateToMaterialDataMap = new HashMap<>();
 
 	private final BlockState blockData;
 	private String name = null;
@@ -165,24 +165,24 @@ public class ForgeMaterialData extends LocalMaterialData
 		return ofBlock(Blocks.AIR, input);
 	}
 		
-	private static LocalMaterialData ofBlock(Block block, String raw)
+	private static ForgeMaterialData ofBlock(Block block, String raw)
 	{
 		return ofBlockState(block.defaultBlockState(), raw);
 	}
 
-	public static LocalMaterialData ofBlockState(BlockState blockData)
+	public static ForgeMaterialData ofBlockState(BlockState blockData)
 	{
 		return ofBlockState(blockData, null);
 	}
 	
-	private static LocalMaterialData ofBlockState(BlockState blockState, String raw)
+	private static ForgeMaterialData ofBlockState(BlockState blockState, String raw)
 	{
 		// Create only one LocalMaterialData object for each BlockState
 		if (stateToMaterialDataMap.containsKey(blockState))
 		{
 			return stateToMaterialDataMap.get(blockState);
 		}
-		LocalMaterialData data = new ForgeMaterialData(blockState, raw);
+		ForgeMaterialData data = new ForgeMaterialData(blockState, raw);
 		stateToMaterialDataMap.put(blockState, data);
 		return data;
 	}	

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/mixin/MixinChunkManager.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/mixin/MixinChunkManager.java
@@ -1,5 +1,9 @@
 package com.pg85.otg.forge.mixin;
 
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkPrimer;
+import net.minecraft.world.chunk.ChunkPrimerWrapper;
+import net.minecraft.world.chunk.IChunk;
 import net.minecraft.world.server.ChunkHolder;
 import net.minecraft.world.server.ChunkManager;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,14 +16,14 @@ import java.util.function.Predicate;
 public class MixinChunkManager
 {
     @ModifyArg(method = "saveAllChunks(Z)V", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;filter(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", ordinal = 0))
-    private Predicate<ChunkHolder> alwaysAccessibleFlush(Predicate<ChunkHolder> chunkHolder)
+    private Predicate<ChunkHolder> alwaysAccessibleFlush(Predicate<ChunkHolder> chunk)
     {
         return c -> true;
-    }
-
-    @ModifyArg(method = "saveAllChunks(Z)V", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;filter(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", ordinal = 3))
-    private Predicate<ChunkHolder> alwaysAccessible(Predicate<ChunkHolder> chunkHolder)
+    }	
+	
+    @ModifyArg(method = "saveAllChunks(Z)V", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;filter(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", ordinal = 1))
+    private Predicate<IChunk> allowChunkPrimerFlush(Predicate<IChunk> chunk)
     {
-        return c -> true;
-    }
+        return c -> c instanceof ChunkPrimer || c instanceof ChunkPrimerWrapper || c instanceof Chunk;
+    }   
 }

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/SpigotWorldGenRegion.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/SpigotWorldGenRegion.java
@@ -267,36 +267,36 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 	public int getBlockAboveLiquidHeight (int x, int z, ChunkCoordinate chunkBeingPopulated)
 	{
 		int highestY = getHighestBlockYAt(x, z, false, true, false, false, false, chunkBeingPopulated);
-		if (highestY > 0)
+		if (highestY >= 0)
 		{
-			highestY += 1;
+			return highestY + 1;
+		} else {
+			return -1;
 		}
-		else
-		{
-			highestY = -1;
-		}
-		return highestY;
 	}
 
 	@Override
 	public int getBlockAboveSolidHeight (int x, int z, ChunkCoordinate chunkBeingPopulated)
 	{
 		int highestY = getHighestBlockYAt(x, z, true, false, true, true, false, chunkBeingPopulated);
-		if (highestY > 0)
+		if (highestY >= 0)
 		{
-			highestY += 1;
+			return highestY + 1;
+		} else {
+			return -1;
 		}
-		else
-		{
-			highestY = -1;
-		}
-		return highestY;
 	}
 
 	@Override
 	public int getHighestBlockAboveYAt (int x, int z, ChunkCoordinate chunkBeingPopulated)
 	{
-		return getHighestBlockYAt(x, z, true, true, false, false, false, chunkBeingPopulated) + 1;
+		int highestY = getHighestBlockYAt(x, z, true, true, false, false, false, chunkBeingPopulated);
+		if (highestY >= 0)
+		{
+			return highestY + 1;
+		} else {
+			return -1;
+		}
 	}
 
 	@Override

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotLegacyMaterials.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotLegacyMaterials.java
@@ -58,38 +58,38 @@ public class SpigotLegacyMaterials
 
 			case "wood_stairs":
 			case "oak_stairs":
-				return Blocks.OAK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.OAK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "birch_wood_stairs":
 			case "birch_stairs":
-				return Blocks.BIRCH_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.BIRCH_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "spruce_wood_stairs":
 			case "spruce_stairs":
-				return Blocks.SPRUCE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.SPRUCE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "jungle_wood_stairs":
 			case "jungle_stairs":
-				return Blocks.JUNGLE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.JUNGLE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "cobblestone_stairs":
 			case "stone_stairs":
-				return Blocks.COBBLESTONE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.COBBLESTONE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "stone_brick_stairs":
 			case "smooth_stairs":
-				return Blocks.STONE_BRICK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.STONE_BRICK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "brick_stairs":
-				return Blocks.BRICK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.BRICK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "nether_brick_stairs":
-				return Blocks.NETHER_BRICK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.NETHER_BRICK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "sandstone_stairs":
-				return Blocks.SANDSTONE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.SANDSTONE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "quartz_stairs":
-				return Blocks.QUARTZ_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.QUARTZ_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "acacia_stairs":
-				return Blocks.ACACIA_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.ACACIA_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "dark_oak_stairs":
-				return Blocks.DARK_OAK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.DARK_OAK_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "red_sandstone_stairs":
-				return Blocks.RED_SANDSTONE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.RED_SANDSTONE_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 			case "purpur_stairs":
-				return Blocks.PURPUR_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.EAST);
+				return Blocks.PURPUR_STAIRS.getBlockData().set(BlockStairs.FACING, EnumDirection.NORTH);
 
 			case "quartz_ore":
 				return Blocks.NETHER_QUARTZ_ORE.getBlockData();				
@@ -501,7 +501,6 @@ public class SpigotLegacyMaterials
 				case "stone_stairs":
 					return getStairsWithData(4, data);
 				case "brick_stairs":
-				case "smooth_stairs":					
 					return getStairsWithData(5, data);
 				case "nether_brick_stairs":
 					return getStairsWithData(7, data);
@@ -518,6 +517,7 @@ public class SpigotLegacyMaterials
 				case "purpur_stairs":
 					return getStairsWithData(13, data);
 				case "stone_brick_stairs":
+				case "smooth_stairs":					
 					return getStairsWithData(14, data);
 				case "lever":
 					return getLeverOrButtonWithData(0, data);


### PR DESCRIPTION
- Fixed a bug for Forge that caused cut-off resources on exit/rejoin (thanks SuperCoder and friends).
- Fixed a whole bunch of legacy block mappings.
- Removed /otg map. Added /otg mapbiomes <width> <height> <threads> and /otg mapterrain <width> <height> <threads>. Default 2048 x 2048 and 1 thread. 4 threads yields best results for me. Forge only atm.
- Cleaned up highestblock detection code, fixes some issues with 1 block tall worlds.
- Made biomeprovider/chunkgenerator thread-safe, or at least to the point where testing with mapping doesn't show any issues. Would need to check all internal state (fields on classes etc) and how it's used to be sure. Using ThreadLocal for some things, ideally should clean this up and reduce the use of state to a minimum.