### PR TITLE
1.16.5-0.0.13: TemplateForBiome (modded biome support)

### DIFF
--- a/common/common-config/src/main/java/com/pg85/otg/config/standard/BiomeStandardValues.java
+++ b/common/common-config/src/main/java/com/pg85/otg/config/standard/BiomeStandardValues.java
@@ -49,7 +49,7 @@ public class BiomeStandardValues extends Settings
 
 	public static final Setting<String>
 		RIVER_BIOME = stringSetting("RiverBiome", "River"),
-		VANILLA_BIOME = stringSetting("ReplaceToBiomeName", ""),
+		TEMPLATE_FOR_BIOME = stringSetting("TemplateForBiome", ""),
 		INHERIT_MOBS_BIOME_NAME = stringSetting("InheritMobsBiomeName", ""),
 		PARTICLE_TYPE = stringSetting("ParticleType", ""),
 		MUSIC = stringSetting("Music", ""),

--- a/common/common-core/src/main/java/com/pg85/otg/config/biome/BiomeConfigBase.java
+++ b/common/common-core/src/main/java/com/pg85/otg/config/biome/BiomeConfigBase.java
@@ -14,11 +14,11 @@ import com.pg85.otg.constants.SettingsEnums.RuinedPortalType;
 import com.pg85.otg.constants.SettingsEnums.VillageType;
 import com.pg85.otg.customobject.resource.CustomStructureResource;
 import com.pg85.otg.gen.surface.SurfaceGenerator;
-import com.pg85.otg.util.biome.BiomeResourceLocation;
 import com.pg85.otg.util.biome.ReplaceBlockMatrix;
 import com.pg85.otg.util.gen.ChunkBuffer;
 import com.pg85.otg.util.gen.GeneratingChunk;
 import com.pg85.otg.util.interfaces.IBiomeConfig;
+import com.pg85.otg.util.interfaces.IBiomeResourceLocation;
 import com.pg85.otg.util.interfaces.ICustomStructureGen;
 import com.pg85.otg.util.interfaces.IWorldConfig;
 import com.pg85.otg.util.interfaces.IWorldGenRegion;
@@ -39,7 +39,7 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 {
 	// Misc
 	
-	private final BiomeResourceLocation registryKey;
+	private IBiomeResourceLocation registryKey;
 	private boolean replacedBlocksInited = false;
 	
 	// TODO: Ideally, don't contain worldConfig within biomeconfig,  
@@ -48,7 +48,7 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	
 	// Identity
 	
-	protected String vanillaBiome;
+	protected String templateForBiome;
 	protected String biomeCategory;
 	
 	// Inheritance
@@ -177,19 +177,23 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	
 	protected List<ConfigFunction<IBiomeConfig>> resourceQueue = new ArrayList<ConfigFunction<IBiomeConfig>>();
 	
-	protected BiomeConfigBase(String configName, BiomeResourceLocation registryKey)
+	protected BiomeConfigBase(String configName)
 	{
 		super(configName);
-		this.registryKey = registryKey;
 	}
-	
+
 	public List<ConfigFunction<IBiomeConfig>> getResourceQueue()
 	{
 		return this.resourceQueue;
 	}
 	
+	public void setRegistryKey(IBiomeResourceLocation registryKey)
+	{
+		this.registryKey = registryKey;
+	}
+	
 	@Override
-	public BiomeResourceLocation getRegistryKey()
+	public IBiomeResourceLocation getRegistryKey()
 	{
 		return this.registryKey;
 	}
@@ -366,6 +370,12 @@ abstract class BiomeConfigBase extends ConfigFile implements IBiomeConfig
 	public String getName()
 	{
 		return this.configName;
+	}
+	
+	@Override
+	public String getTemplateForBiome()
+	{
+		return this.templateForBiome;
 	}
 
 	@Override

--- a/common/common-core/src/main/java/com/pg85/otg/gen/OTGChunkDecorator.java
+++ b/common/common-core/src/main/java/com/pg85/otg/gen/OTGChunkDecorator.java
@@ -200,14 +200,17 @@ public class OTGChunkDecorator implements IChunkDecorator
 				}
 			}
 		}
+	}
 
+	public void doSnowAndIce(IWorldGenRegion worldGenRegion, ChunkCoordinate chunkCoord)
+	{
 		// Snow and ice
 		// TODO: Snow is appearing below structures, indicating it spawned before 
 		// it should. Check and align decoration bounds for resources and make sure
 		// freezing is done during the correct decoration step.
 		FrozenSurfaceHelper.freezeChunk(worldGenRegion, chunkCoord);
 	}
-
+	
 	private void plotAndSpawnBO4s(CustomStructureCache structureCache, IWorldGenRegion worldGenRegion, ChunkCoordinate chunkCoord, ChunkCoordinate chunkBeingDecorated, Path otgRootFolder, boolean developerMode, boolean spawnLog, ILogger logger, CustomObjectManager customObjectManager, IMaterialReader materialReader, CustomObjectResourcesManager customObjectResourcesManager, IModLoadedChecker modLoadedChecker)
 	{
 		// Plot and spawn BO4's for all chunks that may have blocks spawned on them while decorating this chunk, 

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/biome/layers/BiomeGroupLayer.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/biome/layers/BiomeGroupLayer.java
@@ -25,9 +25,7 @@ class BiomeGroupLayer implements ParentedLayer
 		if (data.oldGroupRarity)
 		{
 			this.maxRarity = Math.max(data.cumulativeGroupRarities[depth], 100);
-		}
-		else
-		{
+		} else {
 			this.maxRarity = data.groupMaxRarityPerDepth[depth];
 		}
 		int cumulativeRarity = 0;
@@ -75,7 +73,8 @@ class BiomeGroupLayer implements ParentedLayer
 		// Iterate through the rarity map and see if the chosen rarity is less than the rarity for each group, if it is then return.
 		for (Map.Entry<Integer, NewBiomeGroup> entry : rarityMap.entrySet())
 		{
-			if (chosenRarity < entry.getKey()) {
+			if (chosenRarity < entry.getKey())
+			{
 				return entry.getValue();
 			}
 		}

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/carver/Carver.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/carver/Carver.java
@@ -3,7 +3,6 @@ package com.pg85.otg.gen.carver;
 import java.util.BitSet;
 import java.util.Random;
 
-import com.pg85.otg.constants.Constants;
 import com.pg85.otg.util.MutableBoolean;
 import com.pg85.otg.util.gen.ChunkBuffer;
 import com.pg85.otg.util.gen.DecorationArea;

--- a/common/common-util/src/main/java/com/pg85/otg/util/biome/MCBiomeResourceLocation.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/biome/MCBiomeResourceLocation.java
@@ -1,0 +1,29 @@
+package com.pg85.otg.util.biome;
+
+import com.pg85.otg.util.interfaces.IBiomeResourceLocation;
+
+public class MCBiomeResourceLocation implements IBiomeResourceLocation
+{	
+	private final String domain;
+	private final String path;
+	private final String presetFolder;
+	
+	public MCBiomeResourceLocation(String domain, String path, String presetFolderName)
+	{
+		this.domain = domain;
+		this.path = path;
+		this.presetFolder = presetFolderName;
+	}
+
+	@Override
+	public String getPresetFolderName()
+	{
+		return this.presetFolder;
+	}
+	
+	@Override
+	public String toResourceLocationString()
+	{
+		return String.format("%s%s%s", this.domain, ":", this.path);
+	}
+}

--- a/common/common-util/src/main/java/com/pg85/otg/util/biome/OTGBiomeResourceLocation.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/biome/OTGBiomeResourceLocation.java
@@ -3,8 +3,9 @@ package com.pg85.otg.util.biome;
 import java.nio.file.Path;
 
 import com.pg85.otg.constants.Constants;
+import com.pg85.otg.util.interfaces.IBiomeResourceLocation;
 
-public class BiomeResourceLocation
+public class OTGBiomeResourceLocation implements IBiomeResourceLocation
 {
 	private static final String BIOME_RESOURCE_LOCATION_SEPARATOR = ".";
 
@@ -15,7 +16,7 @@ public class BiomeResourceLocation
 	private final String biomeName;
 	private final String resourceName;
 
-	public BiomeResourceLocation(Path presetFolder, String presetShortName, int presetMajorVersion, String biomeName, String resourceName)
+	public OTGBiomeResourceLocation(Path presetFolder, String presetShortName, int presetMajorVersion, String biomeName, String resourceName)
 	{
 		this.presetMajorVersion = presetMajorVersion;
 		this.presetFolder = presetFolder.toFile().getName();
@@ -25,12 +26,17 @@ public class BiomeResourceLocation
 		this.resourceName = resourceName;
 	}
 
-	public BiomeResourceLocation(Path presetFolder, String presetShortName, int presetMajorVersion, String biomeName)
+	public OTGBiomeResourceLocation(Path presetFolder, String presetShortName, int presetMajorVersion, String biomeName)
 	{
 		this(presetFolder, presetShortName, presetMajorVersion, biomeName, null);
 	}
 	
-	private BiomeResourceLocation(String presetFolderName, String presetShortName, int presetMajorVersion, String presetRegistryName, String biomeName, String resourceName)
+	public IBiomeResourceLocation withBiomeResource(String resourceName)
+	{
+		return new OTGBiomeResourceLocation(this.presetFolder, this.presetShortName, this.presetMajorVersion, this.presetRegistryName, this.biomeName, resourceName);
+	}
+	
+	private OTGBiomeResourceLocation(String presetFolderName, String presetShortName, int presetMajorVersion, String presetRegistryName, String biomeName, String resourceName)
 	{
 		this.presetMajorVersion = presetMajorVersion;
 		this.presetFolder = presetFolderName;
@@ -40,11 +46,18 @@ public class BiomeResourceLocation
 		this.resourceName = resourceName;
 	}
 	
+	@Override
 	public String getPresetFolderName()
 	{
 		return this.presetFolder;
+	}
+	
+	@Override
+	public String toResourceLocationString()
+	{
+		return String.format("%s%s%s", getResourceDomain(), ":", getResourcePath());
 	}	
-
+	
 	private String getResourceDomain()
 	{
 		return Constants.MOD_ID_SHORT;
@@ -58,15 +71,5 @@ public class BiomeResourceLocation
 		} else {			
 			return String.format("%s%s%s", this.presetRegistryName, BIOME_RESOURCE_LOCATION_SEPARATOR, this.biomeName);
 		}
-	}
-
-	public String toResourceLocationString()
-	{
-		return String.format("%s%s%s", getResourceDomain(), ":", getResourcePath());
-	}
-
-	public BiomeResourceLocation withBiomeResource(String resourceName)
-	{
-		return new BiomeResourceLocation(this.presetFolder, this.presetShortName, this.presetMajorVersion, this.presetRegistryName, this.biomeName, resourceName);
 	}
 }

--- a/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IBiomeConfig.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IBiomeConfig.java
@@ -8,7 +8,6 @@ import com.pg85.otg.constants.SettingsEnums.OceanRuinsType;
 import com.pg85.otg.constants.SettingsEnums.RareBuildingType;
 import com.pg85.otg.constants.SettingsEnums.RuinedPortalType;
 import com.pg85.otg.constants.SettingsEnums.VillageType;
-import com.pg85.otg.util.biome.BiomeResourceLocation;
 import com.pg85.otg.util.biome.ReplaceBlockMatrix;
 import com.pg85.otg.util.biome.WeightedMobSpawnGroup;
 import com.pg85.otg.util.gen.ChunkBuffer;
@@ -30,12 +29,12 @@ public interface IBiomeConfig
 	// Misc
 
 	String getName();
-	BiomeResourceLocation getRegistryKey();
+	IBiomeResourceLocation getRegistryKey();
 
 	// WorldConfig getters
 	// TODO: Ideally, don't contain worldConfig within biomeconfig,  
 	// use a parent object that holds both, like a worldgenregion.
-	
+
 	boolean biomeConfigsHaveReplacement();
 	double getFractureHorizontal();
 	double getFractureVertical();
@@ -43,14 +42,15 @@ public interface IBiomeConfig
 	boolean isCeilingBedrock();
 	boolean isBedrockDisabled();
 	boolean isRemoveSurfaceStone();
-	
+
 	// Inheritance
-	
+
 	List<String> getBiomeDictTags();
 	String getBiomeCategory();
-	
+	String getTemplateForBiome();
+
 	// Placement
-	
+
 	int getBiomeSize();
 	int getBiomeRarity();
 	int getBiomeColor();

--- a/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IBiomeResourceLocation.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/interfaces/IBiomeResourceLocation.java
@@ -1,0 +1,7 @@
+package com.pg85.otg.util.interfaces;
+
+public interface IBiomeResourceLocation
+{
+	String toResourceLocationString();
+	String getPresetFolderName();
+}

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/biome/ForgeBiome.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/biome/ForgeBiome.java
@@ -10,6 +10,7 @@ import com.pg85.otg.constants.SettingsEnums.RareBuildingType;
 import com.pg85.otg.constants.SettingsEnums.RuinedPortalType;
 import com.pg85.otg.constants.SettingsEnums.VillageType;
 import com.pg85.otg.logging.LogMarker;
+import com.pg85.otg.util.biome.OTGBiomeResourceLocation;
 import com.pg85.otg.util.biome.WeightedMobSpawnGroup;
 import com.pg85.otg.util.interfaces.IBiome;
 import com.pg85.otg.util.interfaces.IBiomeConfig;
@@ -270,7 +271,7 @@ public class ForgeBiome implements IBiome
 			int villageSize = biomeConfig.getVillageSize();
 			VillageType villageType = biomeConfig.getVillageType();
 			StructureFeature<VillageConfig, ? extends Structure<VillageConfig>> customVillage = register(
-				biomeConfig.getRegistryKey().withBiomeResource("village").toResourceLocationString(),
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("village").toResourceLocationString(),
 				Structure.VILLAGE.configured(
 					new VillageConfig(
 						() -> {
@@ -351,7 +352,7 @@ public class ForgeBiome implements IBiome
 			float mineShaftProbability = biomeConfig.getMineShaftProbability();
 			MineshaftType mineShaftType = biomeConfig.getMineShaftType();
 			StructureFeature<MineshaftConfig, ? extends Structure<MineshaftConfig>> customMineShaft = register(
-				biomeConfig.getRegistryKey().withBiomeResource("mineshaft").toResourceLocationString(),
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("mineshaft").toResourceLocationString(),
 				Structure.MINESHAFT.configured(
 					new MineshaftConfig(
 						mineShaftProbability,
@@ -367,7 +368,7 @@ public class ForgeBiome implements IBiome
 		{
 			float buriedTreasureProbability = biomeConfig.getBuriedTreasureProbability();
 			StructureFeature<ProbabilityConfig, ? extends Structure<ProbabilityConfig>> customBuriedTreasure = register(
-				biomeConfig.getRegistryKey().withBiomeResource("buried_treasure").toResourceLocationString(),
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("buried_treasure").toResourceLocationString(),
 				Structure.BURIED_TREASURE.configured(new ProbabilityConfig(buriedTreasureProbability))
 			);
 			biomeGenerationSettingsBuilder.addStructureStart(customBuriedTreasure);
@@ -380,7 +381,7 @@ public class ForgeBiome implements IBiome
 			float oceanRuinsClusterProbability = biomeConfig.getOceanRuinsClusterProbability();
 			OceanRuinsType oceanRuinsType = biomeConfig.getOceanRuinsType();
 			StructureFeature<OceanRuinConfig, ? extends Structure<OceanRuinConfig>> customOceanRuins = register(
-				biomeConfig.getRegistryKey().withBiomeResource("ocean_ruin").toResourceLocationString(),
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("ocean_ruin").toResourceLocationString(),
 				Structure.OCEAN_RUIN.configured(
 					new OceanRuinConfig(
 						oceanRuinsType == OceanRuinsType.cold ? OceanRuinStructure.Type.COLD : OceanRuinStructure.Type.WARM,
@@ -411,7 +412,7 @@ public class ForgeBiome implements IBiome
 		{
 			int outpostSize = biomeConfig.getPillagerOutPostSize();
 			StructureFeature<VillageConfig, ? extends Structure<VillageConfig>> customOutpost = register(
-				biomeConfig.getRegistryKey().withBiomeResource("pillager_outpost").toResourceLocationString(), 
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("pillager_outpost").toResourceLocationString(), 
 				Structure.PILLAGER_OUTPOST.configured(
 					new VillageConfig(
 						() -> {
@@ -429,7 +430,7 @@ public class ForgeBiome implements IBiome
 		{
 			int bastionRemnantSize = biomeConfig.getBastionRemnantSize();
 			StructureFeature<VillageConfig, ? extends Structure<VillageConfig>> customBastionRemnant = register(
-				biomeConfig.getRegistryKey().withBiomeResource("bastion_remnant").toResourceLocationString(), 
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("bastion_remnant").toResourceLocationString(), 
 				Structure.BASTION_REMNANT.configured(
 					new VillageConfig(
 						() -> {

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/biome/SpigotBiome.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/biome/SpigotBiome.java
@@ -7,6 +7,7 @@ import com.pg85.otg.config.world.WorldConfig;
 import com.pg85.otg.constants.Constants;
 import com.pg85.otg.constants.SettingsEnums;
 import com.pg85.otg.logging.LogMarker;
+import com.pg85.otg.util.biome.OTGBiomeResourceLocation;
 import com.pg85.otg.util.biome.WeightedMobSpawnGroup;
 import com.pg85.otg.util.interfaces.IBiome;
 import com.pg85.otg.util.interfaces.IBiomeConfig;
@@ -164,7 +165,7 @@ public class SpigotBiome implements IBiome
 			int villageSize = biomeConfig.getVillageSize();
 			SettingsEnums.VillageType villageType = biomeConfig.getVillageType();
 			StructureFeature<WorldGenFeatureVillageConfiguration, ? extends StructureGenerator<WorldGenFeatureVillageConfiguration>> customVillage = register(
-					biomeConfig.getRegistryKey().withBiomeResource("village").toResourceLocationString(),
+					((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("village").toResourceLocationString(),
 					StructureGenerator.VILLAGE.a(
 							new WorldGenFeatureVillageConfiguration(
 									() ->
@@ -247,13 +248,13 @@ public class SpigotBiome implements IBiome
 			float mineShaftProbability = biomeConfig.getMineShaftProbability();
 			SettingsEnums.MineshaftType mineShaftType = biomeConfig.getMineShaftType();
 			StructureFeature<WorldGenMineshaftConfiguration, ? extends StructureGenerator<WorldGenMineshaftConfiguration>> customMineShaft = register(
-					biomeConfig.getRegistryKey().withBiomeResource("mineshaft").toResourceLocationString(),
-					StructureGenerator.MINESHAFT.a(
-							new WorldGenMineshaftConfiguration(
-									mineShaftProbability,
-									mineShaftType == SettingsEnums.MineshaftType.mesa ? WorldGenMineshaft.Type.MESA : WorldGenMineshaft.Type.NORMAL
-							)
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("mineshaft").toResourceLocationString(),
+				StructureGenerator.MINESHAFT.a(
+					new WorldGenMineshaftConfiguration(
+						mineShaftProbability,
+						mineShaftType == SettingsEnums.MineshaftType.mesa ? WorldGenMineshaft.Type.MESA : WorldGenMineshaft.Type.NORMAL
 					)
+				)
 			);
 			biomeGenerationSettingsBuilder.a(customMineShaft);
 		}
@@ -263,8 +264,8 @@ public class SpigotBiome implements IBiome
 		{
 			float buriedTreasureProbability = biomeConfig.getBuriedTreasureProbability();
 			StructureFeature<WorldGenFeatureConfigurationChance, ? extends StructureGenerator<WorldGenFeatureConfigurationChance>> customBuriedTreasure = register(
-					biomeConfig.getRegistryKey().withBiomeResource("buried_treasure").toResourceLocationString(),
-					StructureGenerator.BURIED_TREASURE.a(new WorldGenFeatureConfigurationChance(buriedTreasureProbability))
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("buried_treasure").toResourceLocationString(),
+				StructureGenerator.BURIED_TREASURE.a(new WorldGenFeatureConfigurationChance(buriedTreasureProbability))
 			);
 			biomeGenerationSettingsBuilder.a(customBuriedTreasure);
 		}
@@ -276,14 +277,14 @@ public class SpigotBiome implements IBiome
 			float oceanRuinsClusterProbability = biomeConfig.getOceanRuinsClusterProbability();
 			SettingsEnums.OceanRuinsType oceanRuinsType = biomeConfig.getOceanRuinsType();
 			StructureFeature<WorldGenFeatureOceanRuinConfiguration, ? extends StructureGenerator<WorldGenFeatureOceanRuinConfiguration>> customOceanRuins = register(
-					biomeConfig.getRegistryKey().withBiomeResource("ocean_ruin").toResourceLocationString(),
-					StructureGenerator.OCEAN_RUIN.a(
-							new WorldGenFeatureOceanRuinConfiguration(
-									oceanRuinsType == SettingsEnums.OceanRuinsType.cold ? WorldGenFeatureOceanRuin.Temperature.COLD : WorldGenFeatureOceanRuin.Temperature.WARM,
-									oceanRuinsLargeProbability,
-									oceanRuinsClusterProbability
-							)
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("ocean_ruin").toResourceLocationString(),
+				StructureGenerator.OCEAN_RUIN.a(
+					new WorldGenFeatureOceanRuinConfiguration(
+						oceanRuinsType == SettingsEnums.OceanRuinsType.cold ? WorldGenFeatureOceanRuin.Temperature.COLD : WorldGenFeatureOceanRuin.Temperature.WARM,
+						oceanRuinsLargeProbability,
+						oceanRuinsClusterProbability
 					)
+				)
 			);
 			biomeGenerationSettingsBuilder.a(customOceanRuins);
 		}
@@ -307,13 +308,13 @@ public class SpigotBiome implements IBiome
 		{
 			int outpostSize = biomeConfig.getPillagerOutPostSize();
 			StructureFeature<WorldGenFeatureVillageConfiguration, ? extends StructureGenerator<WorldGenFeatureVillageConfiguration>> customOutpost = register(
-					biomeConfig.getRegistryKey().withBiomeResource("pillager_outpost").toResourceLocationString(),
-					StructureGenerator.PILLAGER_OUTPOST.a(
-							new WorldGenFeatureVillageConfiguration(
-									() -> WorldGenFeaturePillagerOutpostPieces.a,
-									outpostSize
-							)
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("pillager_outpost").toResourceLocationString(),
+				StructureGenerator.PILLAGER_OUTPOST.a(
+					new WorldGenFeatureVillageConfiguration(
+						() -> WorldGenFeaturePillagerOutpostPieces.a,
+						outpostSize
 					)
+				)
 			);
 			biomeGenerationSettingsBuilder.a(customOutpost);
 		}
@@ -323,13 +324,13 @@ public class SpigotBiome implements IBiome
 		{
 			int bastionRemnantSize = biomeConfig.getBastionRemnantSize();
 			StructureFeature<WorldGenFeatureVillageConfiguration, ? extends StructureGenerator<WorldGenFeatureVillageConfiguration>> customBastionRemnant = register(
-					biomeConfig.getRegistryKey().withBiomeResource("bastion_remnant").toResourceLocationString(),
-					StructureGenerator.BASTION_REMNANT.a(
-							new WorldGenFeatureVillageConfiguration(
-									() -> WorldGenFeatureBastionPieces.a,
-									bastionRemnantSize
-							)
+				((OTGBiomeResourceLocation)biomeConfig.getRegistryKey()).withBiomeResource("bastion_remnant").toResourceLocationString(),
+				StructureGenerator.BASTION_REMNANT.a(
+					new WorldGenFeatureVillageConfiguration(
+						() -> WorldGenFeatureBastionPieces.a,
+						bastionRemnantSize
 					)
+				)
 			);
 			biomeGenerationSettingsBuilder.a(customBastionRemnant);
 		}

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/presets/SpigotPresetLoader.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/presets/SpigotPresetLoader.java
@@ -13,7 +13,7 @@ import com.pg85.otg.logging.LogMarker;
 import com.pg85.otg.presets.LocalPresetLoader;
 import com.pg85.otg.presets.Preset;
 import com.pg85.otg.spigot.biome.SpigotBiome;
-import com.pg85.otg.util.biome.BiomeResourceLocation;
+import com.pg85.otg.util.biome.OTGBiomeResourceLocation;
 
 import net.minecraft.server.v1_16_R3.*;
 import org.bukkit.Bukkit;
@@ -198,7 +198,7 @@ public class SpigotPresetLoader extends LocalPresetLoader
 				// Add each biome to the group
 				for (String biome : group.biomes.keySet())
 				{
-					MinecraftKey location = new MinecraftKey(new BiomeResourceLocation(preset.getPresetFolder(), preset.getShortPresetName(), preset.getMajorVersion(), biome).toResourceLocationString());
+					MinecraftKey location = new MinecraftKey(new OTGBiomeResourceLocation(preset.getPresetFolder(), preset.getShortPresetName(), preset.getMajorVersion(), biome).toResourceLocationString());
 					BiomeConfig config = this.biomeConfigsByRegistryKey.get(location);
 					if (config == null)
 					{


### PR DESCRIPTION
- Added TemplateForBiome: <biomeregistryname>. OTG uses the specified biome during biomegen/decoration. OTG handles terrain generation, and also spawns its own resources before spawning any (non-OTG) resources belonging to the biome. Any OTG settings that are registered to biomes and passed to MC won't work for these biomes, all other settings should work.