### PR TITLE
1.16.5-0.0.16: /otg spawn for bo4 branches

### DIFF
--- a/common/common-util/src/main/java/com/pg85/otg/util/gen/LocalWorldGenRegion.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/gen/LocalWorldGenRegion.java
@@ -34,6 +34,9 @@ public abstract class LocalWorldGenRegion implements IWorldGenRegion
 		this.pluginConfig = pluginConfig;
 		this.worldConfig = worldConfig;
 		this.logger = logger;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.
 		this.decorationBiomeCache = null;
 		this.decorationArea = null;
 	}

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/commands/SpawnCommand.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/commands/SpawnCommand.java
@@ -128,14 +128,49 @@ public class SpawnCommand implements BaseCommand
 	        		return 0;
 	        	}
 	        	
+	            int playerX = blockPos.getX();
+	            int playerZ = blockPos.getZ();
+	            ChunkCoordinate playerChunk = ChunkCoordinate.fromBlockCoords(playerX, playerZ);
+	        	
+	            // Matches any bo4/bo4data file ending with C[0-9]R[0-9], assuming it's not a start
+	            // bo4 for a structure, but rather a branch that should be spawned individually.	            
+	        	if(((BO4)objectToSpawn).getName().matches(".*C[0-9]([0-9]*)R[0-9]([0-9]*)$"))
+	        	{
+	        		((BO4)objectToSpawn).trySpawnAt(
+        				preset.getFolderName(), 
+        				OTG.getEngine().getOTGRootFolder(), 
+        				OTG.getEngine().getLogger(), 
+        				OTG.getEngine().getCustomObjectManager(), 
+        				OTG.getEngine().getPresetLoader().getMaterialReader(preset.getFolderName()), 
+        				OTG.getEngine().getCustomObjectResourcesManager(), 
+        				null, 
+        				genRegion, 
+        				new Random(), 
+        				Rotation.NORTH, 
+        				playerChunk, 
+        				playerChunk.getBlockX() + ((BO4)objectToSpawn).getConfig().getminX(), 
+        				genRegion.getHighestBlockAboveYAt(playerChunk.getBlockX() + ((BO4)objectToSpawn).getConfig().getminX(), playerChunk.getBlockZ() + ((BO4)objectToSpawn).getConfig().getminZ()),
+        				playerChunk.getBlockZ() + ((BO4)objectToSpawn).getConfig().getminZ(), 
+        				null, 
+        				null, 
+        				false, 
+        				null, 
+        				null,
+        				null,
+        				false, 
+        				63, 
+        				false, 
+        				false, 
+        				false
+    				);
+	        		return 0;
+	        	}
+	        	
 				CustomStructureCache cache = ((OTGNoiseChunkGenerator) source.getLevel().getChunkSource().getGenerator()).getStructureCache(worldSaveFolder);
 	        	
 	        	// Try spawning the structure in available chunks around the player
 	        	int maxRadius = 1000;
 	        	source.sendSuccess(new StringTextComponent("Trying to plot BO4 structure within " + maxRadius + " chunks of player, with height bounds " + (force ? "disabled" : "enabled") + ". This may take a while."), false);
-	            int playerX = blockPos.getX();
-	            int playerZ = blockPos.getZ();
-	            ChunkCoordinate playerChunk = ChunkCoordinate.fromBlockCoords(playerX, playerZ);
 
 	            ChunkCoordinate chunkCoord;
 	            for (int cycle = 1; cycle < maxRadius; cycle++)
@@ -217,6 +252,7 @@ public class SpawnCommand implements BaseCommand
 		catch (Exception e)
 		{
 			source.sendSuccess(new StringTextComponent("Something went wrong, please check logs"), false);
+			OTG.getEngine().getLogger().log(LogLevel.ERROR, LogCategory.MAIN, "Error during spawn command: ");
 			OTG.getEngine().getLogger().log(LogLevel.ERROR, LogCategory.MAIN, String.format("Error during spawn command: ", (Object[])e.getStackTrace()));
 		}
 		return 0;

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/gen/ForgeWorldGenRegion.java
@@ -110,13 +110,19 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 	@Override
 	public IBiome getBiomeForDecoration(int x, int z)
 	{
-		return this.decorationBiomeCache.getBiome(x, z);
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration. 
+		return this.decorationBiomeCache != null ? this.decorationBiomeCache.getBiome(x, z) : this.getCachedBiomeProvider().getBiome(x, z);		
 	}
 
 	@Override
 	public IBiomeConfig getBiomeConfigForDecoration(int x, int z)
 	{
-		return this.decorationBiomeCache.getBiomeConfig(x, z);
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
+		return this.decorationBiomeCache != null ? this.decorationBiomeCache.getBiomeConfig(x, z) : this.getCachedBiomeProvider().getBiomeConfig(x, z);
 	}
 
 	@Override
@@ -142,6 +148,9 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 		ChunkCoordinate chunkCoord = ChunkCoordinate.fromBlockCoords(x, z);
 
 		IChunk chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if(this.decorationArea == null || this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.hasChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;
@@ -202,6 +211,9 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 		
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunk chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if(this.decorationArea == null || this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.hasChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;
@@ -358,6 +370,9 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 
 		// If no decorationArea is present, we're doing something outside of the decoration cycle.
 		// If a decorationArea exists, only spawn in the area being decorated.
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if(this.decorationArea == null || this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			if(replaceBlocksMatrix != null)
@@ -615,6 +630,9 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunk chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if(this.decorationArea != null && this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.hasChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;
@@ -640,6 +658,9 @@ public class ForgeWorldGenRegion extends LocalWorldGenRegion
 		
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunk chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if(this.decorationArea != null && this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.hasChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunk(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/commands/SpawnCommand.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/commands/SpawnCommand.java
@@ -102,15 +102,50 @@ public class SpawnCommand implements BaseCommand
         		return true;
         	}
 
+            int playerX = block.getX();
+            int playerZ = block.getZ();
+            ChunkCoordinate playerChunk = ChunkCoordinate.fromBlockCoords(playerX, playerZ);
+        	
+            // Matches any bo4/bo4data file ending with C[0-9]R[0-9], assuming it's not a start
+            // bo4 for a structure, but rather a branch that should be spawned individually.
+        	if(((BO4)objectToSpawn).getName().matches(".*C[0-9]([0-9]*)R[0-9]([0-9]*)$"))
+        	{
+        		((BO4)objectToSpawn).trySpawnAt(
+    				preset.getFolderName(), 
+    				OTG.getEngine().getOTGRootFolder(), 
+    				OTG.getEngine().getLogger(), 
+    				OTG.getEngine().getCustomObjectManager(), 
+    				OTG.getEngine().getPresetLoader().getMaterialReader(preset.getFolderName()), 
+    				OTG.getEngine().getCustomObjectResourcesManager(), 
+    				null, 
+    				genRegion, 
+    				new Random(), 
+    				Rotation.NORTH, 
+    				playerChunk, 
+    				playerChunk.getBlockX() + ((BO4)objectToSpawn).getConfig().getminX(), 
+    				genRegion.getHighestBlockAboveYAt(playerChunk.getBlockX() + ((BO4)objectToSpawn).getConfig().getminX(), playerChunk.getBlockZ() + ((BO4)objectToSpawn).getConfig().getminZ()),
+    				playerChunk.getBlockZ() + ((BO4)objectToSpawn).getConfig().getminZ(), 
+    				null, 
+    				null, 
+    				false, 
+    				null, 
+    				null,
+    				null,
+    				false, 
+    				63, 
+    				false, 
+    				false, 
+    				false
+				);
+        		return true;
+        	}
+        	
     		CustomStructureCache cache = ((OTGSpigotChunkGen)((CraftWorld)((Player)sender).getWorld()).getGenerator()).generator.getStructureCache(player.getWorld().getWorldFolder().toPath());
 
         	// Try spawning the structure in available chunks around the player
             int maxRadius = 1000;  
             OTG.getEngine().getLogger().log(LogLevel.INFO, LogCategory.MAIN, "Trying to plot BO4 structure within " + maxRadius + " chunks of player, with height bounds " + (force ? "disabled" : "enabled") + ". This may take a while."); 
             sender.sendMessage("Trying to plot BO4 structure within " + maxRadius + " chunks of player, with height bounds " + (force ? "disabled" : "enabled") + ". This may take a while.");
-            int playerX = block.getX();
-            int playerZ = block.getZ();
-            ChunkCoordinate playerChunk = ChunkCoordinate.fromBlockCoords(playerX, playerZ);
             ChunkCoordinate chunkCoord;
             for (int cycle = 1; cycle < maxRadius; cycle++)
             {

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/SpigotWorldGenRegion.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/gen/SpigotWorldGenRegion.java
@@ -91,13 +91,19 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 	@Override
 	public IBiome getBiomeForDecoration(int x, int z)
 	{
-		return this.decorationBiomeCache.getBiome(x, z);
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
+		return this.decorationArea != null ? this.decorationBiomeCache.getBiome(x, z) : this.getCachedBiomeProvider().getBiome(x, z);
 	}
 
 	@Override
 	public IBiomeConfig getBiomeConfigForDecoration(int x, int z)
 	{
-		return this.decorationBiomeCache.getBiomeConfig(x, z);
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
+		return this.decorationArea != null ? this.decorationBiomeCache.getBiomeConfig(x, z) : this.getCachedBiomeProvider().getBiomeConfig(x, z);
 	}
 
 	@Override
@@ -124,6 +130,9 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunkAccess chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if (this.decorationArea == null || this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.isChunkLoaded(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunkAt(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;
@@ -184,6 +193,9 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunkAccess chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if (this.decorationArea == null || this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.isChunkLoaded(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunkAt(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;
@@ -339,6 +351,9 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 
 		// If no decorationArea is present, we're doing something outside of the decoration cycle.
 		// If a decorationArea exists, only spawn in the area being decorated.
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if(this.decorationArea == null || this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			if(replaceBlocksMatrix != null)
@@ -584,6 +599,9 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunkAccess chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if (this.decorationArea != null && this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.isChunkLoaded(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunkAt(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;
@@ -607,6 +625,9 @@ public class SpigotWorldGenRegion extends LocalWorldGenRegion
 
 		// If the chunk exists or is inside the area being decorated, fetch it normally.
 		IChunkAccess chunk = null;
+		// TOOD: Don't use this.decorationArea == null for worldgenregions
+		// doing things outside of population, split up worldgenregion
+		// into separate classes, one for decoration, one for non-decoration.		
 		if (this.decorationArea != null && this.decorationArea.isInAreaBeingDecorated(x, z))
 		{
 			chunk = this.worldGenRegion.isChunkLoaded(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) ? this.worldGenRegion.getChunkAt(chunkCoord.getChunkX(), chunkCoord.getChunkZ()) : null;


### PR DESCRIPTION
- /otg spawn works like it does for bo3's when targeting bo4 objects with a name that ends with C<number>R<number>. These are assumed to be branches, not structure starts and so are spawned individually at player position, like regular bo3's.