### PR TITLE
Added WORLD_PRELOADED helper file and fixed Spigot spawn location mis…

### DIFF
--- a/platforms/spigot/src/main/java/com/pg85/spigot/events/OTGHandler.java
+++ b/platforms/spigot/src/main/java/com/pg85/spigot/events/OTGHandler.java
@@ -1,6 +1,13 @@
 package com.pg85.spigot.events;
 
+import com.pg85.otg.OTG;
+import com.pg85.otg.interfaces.ILogger;
+import com.pg85.otg.util.logging.LogCategory;
+import com.pg85.otg.util.logging.LogLevel;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -8,6 +15,11 @@ import org.bukkit.event.world.StructureGrowEvent;
 
 import com.pg85.otg.constants.Constants;
 import com.pg85.otg.spigot.OTGPlugin;
+import org.bukkit.event.world.WorldLoadEvent;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
 
 public class OTGHandler implements Listener
 {
@@ -24,5 +36,25 @@ public class OTGHandler implements Listener
 	public void onStructureGrow(StructureGrowEvent event)
 	{
 		saplingHandler.onStructureGrow(event);
+	}
+
+	@EventHandler(priority = EventPriority.LOW)
+	public void onWorldLoaded(WorldLoadEvent evt) {
+		World world = evt.getWorld();
+		File WORLD_PRELOADED_FILE = new File(world.getWorldFolder() + "/WORLD_PRELOADED");
+		if (!WORLD_PRELOADED_FILE.exists()) {
+			Location spawn = world.getSpawnLocation();
+			int Y;
+			for (Y = world.getMaxHeight()-1; world.getBlockAt(spawn.getBlockX(), Y, spawn.getBlockZ()).getType() == Material.AIR; Y--);
+			world.setSpawnLocation(spawn.getBlockX(), Y, spawn.getBlockZ());
+			try {
+				WORLD_PRELOADED_FILE.createNewFile();
+			} catch (IOException e) {
+				ILogger log = OTG.getEngine().getLogger();
+				log.log(LogLevel.WARN, LogCategory.MAIN,"Could not save data that the world is already loaded! Spawn will be reset next time the server restarts!");
+				log.log(LogLevel.WARN, LogCategory.MAIN, "Message: " + e.getMessage());
+				e.printStackTrace();
+			}
+		}
 	}
 }


### PR DESCRIPTION
…haps.

The WORLD_PRELOADED file should be useful in the future as well.

I will point this out. In a previous test of what I was doing I had spawn locations well into the hundreds, but it appears as if one thing I did somehow fixed that -- I generated multiple test worlds and the problem appears to be gone. Even if it's still around Spigot will just put the player on the ground anyways. If this problem starts to show up I'll have a look at it but I'm 99% sure it's patched.

Other than that we should be good.