### PR TITLE
BerryBush spawn clusters fixes #640

### DIFF
--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/BerryBush.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/BerryBush.java
@@ -1,0 +1,81 @@
+package com.pg85.otg.gen.resource;
+
+import com.pg85.otg.constants.Constants;
+import com.pg85.otg.interfaces.IWorldGenRegion;
+import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterials;
+import com.pg85.otg.util.materials.MaterialProperties;
+import com.pg85.otg.util.materials.MaterialSet;
+
+import java.util.Random;
+
+public class BerryBush {
+
+    protected enum SparseOption {
+        Sparse,
+        Decorated
+    }
+
+    protected static void spawnBerryBushes(IWorldGenRegion worldGenregion, Random random, int centerX, int centerZ, int frequency, int minAltitude, int maxAltitude, MaterialSet sourceBlocks, SparseOption sparseOption) {
+            int centerY = worldGenregion.getHighestBlockAboveYAt(centerX, centerZ);
+
+            if (centerY < Constants.WORLD_DEPTH) {
+                return;
+            }
+
+            LocalMaterialData worldMaterial;
+
+            // Fix y position
+            while (
+                    (
+                            //stay in y bounds
+                            (centerY >= Constants.WORLD_DEPTH && centerY < Constants.WORLD_HEIGHT) &&
+                                    //null check
+                                    (worldMaterial = worldGenregion.getMaterial(centerX, centerY, centerZ)) != null &&
+                                    //if air or leaves
+                                    (
+                                            worldMaterial.isAir() ||
+                                                    worldMaterial.isLeaves()
+                                    ) &&
+                                    worldGenregion.getMaterial(centerX, centerY - 1, centerZ) != null
+                    ) && (
+                            centerY > 0
+                    )
+            ) {
+                //move down
+                centerY--;
+            }
+            centerY++;
+
+            // Try to place BERRY BUSH
+            int x;
+            int y;
+            int z;
+
+            int xzBounds = (sparseOption == SparseOption.Sparse) ? 7 : 5;
+            int yBounds = (sparseOption == SparseOption.Sparse) ? 4 : 3;
+            frequency += (sparseOption == SparseOption.Sparse) ? 0 : 10;
+
+            for (int i = 0; i < frequency; i++) {
+                x = centerX + random.nextInt(xzBounds) - random.nextInt(xzBounds);
+                y = centerY + random.nextInt(yBounds) - random.nextInt(yBounds);
+                z = centerZ + random.nextInt(xzBounds) - random.nextInt(xzBounds);
+                //spawn if the block is in min/max altitude and block below is a source block
+                if (
+                        (worldMaterial = worldGenregion.getMaterial(x, y, z)) != null &&
+                                worldMaterial.isAir() &&
+                                (
+                                        (worldMaterial = worldGenregion.getMaterial(x, y - 1, z)) != null &&
+                                                sourceBlocks.contains(worldMaterial)
+                                ) &&
+                                (
+                                        y >= minAltitude && y < maxAltitude
+                                )
+                ) {
+                    //set block directly so we can set the age of the berry bush
+                    worldGenregion.setBlock(x, y, z, LocalMaterials.BERRY_BUSH.withProperty(MaterialProperties.AGE_0_3, random.nextInt(4)));
+                }
+            }
+
+    }
+}

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/PlantResource.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/PlantResource.java
@@ -46,7 +46,7 @@ public class PlantResource extends FrequencyResourceBase
 	public void spawn(IWorldGenRegion worldGenregion, Random rand, int x, int z)
 	{
         if (sparseOption != null && plant == PlantType.BerryBush){
-            BerryBush.spawnBerryBushes(worldGenregion, rand, x, z, frequency, minAltitude, maxAltitude, sourceBlocks, sparseOption);
+            BerryBush.spawnBerryBushes(worldGenregion, rand, x, z, plant, frequency, minAltitude, maxAltitude, sourceBlocks, sparseOption);
 			return;
         }
 		int y = RandomHelper.numberInRange(rand, this.minAltitude, this.maxAltitude);
@@ -79,7 +79,7 @@ public class PlantResource extends FrequencyResourceBase
 	@Override
 	public String toString()
 	{
-		String sparse = (sparseOption == null ||  plant != PlantType.BerryBush) ? "" : sparseOption + ",";
+		String sparse = (sparseOption == null) ? "" : sparseOption + ",";
 		return "Plant(" + this.plant.getName() + "," + sparse + this.frequency + "," + this.rarity + "," + this.minAltitude + "," + this.maxAltitude + makeMaterials(this.sourceBlocks) + ")";
 	}
 }

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/PlantResource.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/PlantResource.java
@@ -2,6 +2,7 @@ package com.pg85.otg.gen.resource;
 
 import com.pg85.otg.constants.Constants;
 import com.pg85.otg.exceptions.InvalidConfigException;
+import com.pg85.otg.gen.resource.util.BerryBush;
 import com.pg85.otg.interfaces.IBiomeConfig;
 import com.pg85.otg.interfaces.ILogger;
 import com.pg85.otg.interfaces.IMaterialReader;
@@ -10,7 +11,7 @@ import com.pg85.otg.util.helpers.RandomHelper;
 import com.pg85.otg.util.materials.LocalMaterialData;
 import com.pg85.otg.util.materials.MaterialSet;
 import com.pg85.otg.util.minecraft.PlantType;
-import com.pg85.otg.gen.resource.BerryBush.SparseOption;
+import com.pg85.otg.gen.resource.util.BerryBush.SparseOption;
 
 import java.util.List;
 import java.util.Random;

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/PlantResource.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/PlantResource.java
@@ -10,6 +10,7 @@ import com.pg85.otg.util.helpers.RandomHelper;
 import com.pg85.otg.util.materials.LocalMaterialData;
 import com.pg85.otg.util.materials.MaterialSet;
 import com.pg85.otg.util.minecraft.PlantType;
+import com.pg85.otg.gen.resource.BerryBush.SparseOption;
 
 import java.util.List;
 import java.util.Random;
@@ -20,6 +21,7 @@ public class PlantResource extends FrequencyResourceBase
 	private final int minAltitude;
 	private final PlantType plant;
 	private final MaterialSet sourceBlocks;
+	private SparseOption sparseOption = null;
 
 	public PlantResource(IBiomeConfig biomeConfig, List<String> args, ILogger logger, IMaterialReader materialReader) throws InvalidConfigException
 	{
@@ -27,16 +29,25 @@ public class PlantResource extends FrequencyResourceBase
 		assureSize(6, args);
 
 		this.plant = PlantType.getPlant(args.get(0), materialReader);
-		this.frequency = readInt(args.get(1), 1, 100);
-		this.rarity = readRarity(args.get(2));
-		this.minAltitude = readInt(args.get(3), Constants.WORLD_DEPTH, Constants.WORLD_HEIGHT - 1);
-		this.maxAltitude = readInt(args.get(4), this.minAltitude, Constants.WORLD_HEIGHT - 1);
-		this.sourceBlocks = readMaterials(args, 5, materialReader);
+        int i = 0;
+		if (args.get(1).equalsIgnoreCase("Sparse") || args.get(1).equalsIgnoreCase("Decorated")){
+			this.sparseOption = args.get(1).equalsIgnoreCase("Sparse") ? SparseOption.Sparse : SparseOption.Decorated;
+            i = 1;
+		}
+		this.frequency = readInt(args.get(1 + i), 1, 100);
+		this.rarity = readRarity(args.get(2 + i));
+		this.minAltitude = readInt(args.get(3 + i), Constants.WORLD_DEPTH, Constants.WORLD_HEIGHT - 1);
+		this.maxAltitude = readInt(args.get(4 + i), this.minAltitude, Constants.WORLD_HEIGHT - 1);
+		this.sourceBlocks = readMaterials(args, 5 + i, materialReader);
 	}
 
 	@Override
 	public void spawn(IWorldGenRegion worldGenregion, Random rand, int x, int z)
 	{
+        if (sparseOption != null && plant == PlantType.BerryBush){
+            BerryBush.spawnBerryBushes(worldGenregion, rand, x, z, frequency, minAltitude, maxAltitude, sourceBlocks, sparseOption);
+			return;
+        }
 		int y = RandomHelper.numberInRange(rand, this.minAltitude, this.maxAltitude);
 
 		LocalMaterialData worldMaterial;
@@ -67,6 +78,7 @@ public class PlantResource extends FrequencyResourceBase
 	@Override
 	public String toString()
 	{
-		return "Plant(" + this.plant.getName() + "," + this.frequency + "," + this.rarity + "," + this.minAltitude + "," + this.maxAltitude + makeMaterials(this.sourceBlocks) + ")";
-	}	
+		String sparse = (sparseOption == null ||  plant != PlantType.BerryBush) ? "" : sparseOption + ",";
+		return "Plant(" + this.plant.getName() + "," + sparse + this.frequency + "," + this.rarity + "," + this.minAltitude + "," + this.maxAltitude + makeMaterials(this.sourceBlocks) + ")";
+	}
 }

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/util/BerryBush.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/util/BerryBush.java
@@ -1,4 +1,4 @@
-package com.pg85.otg.gen.resource;
+package com.pg85.otg.gen.resource.util;
 
 import com.pg85.otg.constants.Constants;
 import com.pg85.otg.interfaces.IWorldGenRegion;
@@ -11,12 +11,12 @@ import java.util.Random;
 
 public class BerryBush {
 
-    protected enum SparseOption {
+    public enum SparseOption {
         Sparse,
         Decorated
     }
 
-    protected static void spawnBerryBushes(IWorldGenRegion worldGenregion, Random random, int centerX, int centerZ, int frequency, int minAltitude, int maxAltitude, MaterialSet sourceBlocks, SparseOption sparseOption) {
+    public static void spawnBerryBushes(IWorldGenRegion worldGenregion, Random random, int centerX, int centerZ, int frequency, int minAltitude, int maxAltitude, MaterialSet sourceBlocks, SparseOption sparseOption) {
             int centerY = worldGenregion.getHighestBlockAboveYAt(centerX, centerZ);
 
             if (centerY < Constants.WORLD_DEPTH) {

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/util/BerryBush.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/util/BerryBush.java
@@ -6,6 +6,7 @@ import com.pg85.otg.util.materials.LocalMaterialData;
 import com.pg85.otg.util.materials.LocalMaterials;
 import com.pg85.otg.util.materials.MaterialProperties;
 import com.pg85.otg.util.materials.MaterialSet;
+import com.pg85.otg.util.minecraft.PlantType;
 
 import java.util.Random;
 
@@ -16,7 +17,7 @@ public class BerryBush {
         Decorated
     }
 
-    public static void spawnBerryBushes(IWorldGenRegion worldGenregion, Random random, int centerX, int centerZ, int frequency, int minAltitude, int maxAltitude, MaterialSet sourceBlocks, SparseOption sparseOption) {
+    public static void spawnBerryBushes(IWorldGenRegion worldGenregion, Random random, int centerX, int centerZ, PlantType plant, int frequency, int minAltitude, int maxAltitude, MaterialSet sourceBlocks, SparseOption sparseOption) {
             int centerY = worldGenregion.getHighestBlockAboveYAt(centerX, centerZ);
 
             if (centerY < Constants.WORLD_DEPTH) {
@@ -72,8 +73,12 @@ public class BerryBush {
                                         y >= minAltitude && y < maxAltitude
                                 )
                 ) {
-                    //set block directly so we can set the age of the berry bush
-                    worldGenregion.setBlock(x, y, z, LocalMaterials.BERRY_BUSH.withProperty(MaterialProperties.AGE_0_3, random.nextInt(4)));
+                    if (plant == PlantType.BerryBush) {
+                        //set block directly so we can set the age of the berry bush
+                        worldGenregion.setBlock(x, y, z, LocalMaterials.BERRY_BUSH.withProperty(MaterialProperties.AGE_0_3, random.nextInt(4)));
+                    } else {
+                        plant.spawn(worldGenregion, x, y, z);
+                    }
                 }
             }
 

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterials.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/LocalMaterials.java
@@ -182,4 +182,6 @@ public class LocalMaterials
 	public static LocalMaterialData COAL_BLOCK;
 	public static LocalMaterialData QUARTZ_BLOCK;
 	public static LocalMaterialData EMERALD_BLOCK;
+
+	public static LocalMaterialData BERRY_BUSH;
 }

--- a/common/common-util/src/main/java/com/pg85/otg/util/materials/MaterialProperties.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/materials/MaterialProperties.java
@@ -5,6 +5,7 @@ import com.pg85.otg.util.OTGDirection;
 public class MaterialProperties
 {
 	public static final MaterialProperty<Integer> AGE_0_25 = new MaterialProperty<>("age");
+	public static final MaterialProperty<Integer> AGE_0_3 = new MaterialProperty<>("age");
 	public static final MaterialProperty<Integer> PICKLES_1_4 = new MaterialProperty<>("pickles");
 
 	public static final MaterialProperty<Boolean> SNOWY = new MaterialProperty<>("snowy");

--- a/common/common-util/src/main/java/com/pg85/otg/util/minecraft/PlantType.java
+++ b/common/common-util/src/main/java/com/pg85/otg/util/minecraft/PlantType.java
@@ -43,6 +43,7 @@ public class PlantType
 	public static final PlantType Sunflower = register(new PlantType("Sunflower", new String[] { "minecraft:double_plant", "double_plant", "minecraft:double_plant:0", "double_plant:0" }, LocalMaterials.SUNFLOWER_LOWER, LocalMaterials.SUNFLOWER_UPPER));
 	public static final PlantType Tallgrass = register(new PlantType("Tallgrass", LocalMaterials.LONG_GRASS));
 	public static final PlantType WhiteTulip = register(new PlantType("WhiteTulip", LocalMaterials.WHITE_TULIP));
+	public static final PlantType BerryBush = register(new PlantType("BerryBush", LocalMaterials.BERRY_BUSH));
 	
 	/**
 	 * Gets the plant with the given name. The name can be one of the premade

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialData.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterialData.java
@@ -270,6 +270,10 @@ public class ForgeMaterialData extends LocalMaterialData
 		{
 			property = BlockStateProperties.AGE_25;
 		}
+		else if (materialProperty == MaterialProperties.AGE_0_3)
+		{
+			property = BlockStateProperties.AGE_3;
+		}
 		else if (materialProperty == MaterialProperties.PICKLES_1_4)
 		{
 			property = BlockStateProperties.PICKLES;

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterials.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/materials/ForgeMaterials.java
@@ -1,6 +1,7 @@
 package com.pg85.otg.forge.materials;
 
 import com.pg85.otg.constants.Constants;
+import com.pg85.otg.util.materials.LocalMaterialData;
 import com.pg85.otg.util.materials.LocalMaterials;
 
 import net.minecraft.block.*;
@@ -326,5 +327,7 @@ public class ForgeMaterials extends LocalMaterials
 		COAL_BLOCK = ForgeMaterialData.ofBlockState(Blocks.COAL_BLOCK.defaultBlockState());
 		QUARTZ_BLOCK = ForgeMaterialData.ofBlockState(Blocks.QUARTZ_BLOCK.defaultBlockState());
 		EMERALD_BLOCK = ForgeMaterialData.ofBlockState(Blocks.EMERALD_BLOCK.defaultBlockState());
+
+		BERRY_BUSH = ForgeMaterialData.ofBlockState(Blocks.SWEET_BERRY_BUSH.defaultBlockState());
 	}
 }

--- a/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterials.java
+++ b/platforms/spigot/src/main/java/com/pg85/otg/spigot/materials/SpigotMaterials.java
@@ -323,5 +323,7 @@ public class SpigotMaterials extends LocalMaterials
 		COAL_BLOCK = SpigotMaterialData.ofBlockData(Blocks.COAL_BLOCK.getBlockData());
 		QUARTZ_BLOCK = SpigotMaterialData.ofBlockData(Blocks.QUARTZ_BLOCK.getBlockData());
 		EMERALD_BLOCK = SpigotMaterialData.ofBlockData(Blocks.EMERALD_BLOCK.getBlockData());
+
+		BERRY_BUSH = SpigotMaterialData.ofBlockData(Blocks.SWEET_BERRY_BUSH.getBlockData());
 	}
 }


### PR DESCRIPTION
-added BerryBush.java with generation code for two types of spawn clusters
-added BerryBush as a PlantType
-added BERRY_BUSH as Local/Spigot/Forge Material 
-added MaterialProperty AGE_0_3 (so Bushes can be spawned with different growth states) 
-added optional parameter (Sparse/Decorated) to Plant() Resource
  e.g. Plant(BerryBush,Decorated,2,5.0,0,255,minecraft:grass_block)