### PR TITLE
1.12 otg+ [FixedRotation & ChunkCache]

### DIFF
--- a/common/src/main/java/com/pg85/otg/customobjects/bo4/BO4Config.java
+++ b/common/src/main/java/com/pg85/otg/customobjects/bo4/BO4Config.java
@@ -54,6 +54,7 @@ public class BO4Config extends CustomObjectConfigFile
     public ConfigMode settingsMode;
     public boolean doReplaceBlocks;
     public int frequency;
+	public Rotation fixedRotation;
     
     private final int xSize = 16;
     private final int zSize = 16;
@@ -1067,6 +1068,10 @@ public class BO4Config extends CustomObjectConfigFile
         // Main settings
         writer.bigTitle("Main settings");
 
+		writer.comment("If this BO4 should spawn with a fixed rotation, set it here.");
+		writer.comment("For example: NORTH, EAST, SOUTH or WEST. Empty by default");
+		writer.setting(BO4Settings.FIXED_ROTATION, this.fixedRotation == null ? "" : this.fixedRotation.name());
+
 		writer.comment("This BO4 can only spawn at least Frequency chunks distance away from any other BO4 with the exact same name.");
 		writer.comment("You can use this to make this BO4 spawn in groups or make sure that this BO4 only spawns once every X chunks.");
         writer.setting(BO4Settings.FREQUENCY, this.frequency);
@@ -1343,7 +1348,10 @@ public class BO4Config extends CustomObjectConfigFile
         this.maxHeight = this.maxHeight < this.minHeight ? this.minHeight : this.maxHeight;
 
         this.doReplaceBlocks = readSettings(BO4Settings.DO_REPLACE_BLOCKS);
-        
+
+		String fixedRotation = readSettings(BO4Settings.FIXED_ROTATION);
+		this.fixedRotation = fixedRotation == null || fixedRotation.trim().length() == 0 ? null : Rotation.FromString(fixedRotation);
+
         // Read the resources
         readResources();
 

--- a/common/src/main/java/com/pg85/otg/customobjects/bo4/BO4Settings.java
+++ b/common/src/main/java/com/pg85/otg/customobjects/bo4/BO4Settings.java
@@ -55,7 +55,9 @@ class BO4Settings extends Settings
 		SMOOTHINGGROUNDBLOCK = stringSetting("SmoothingGroundBlock", ""),
 		MUSTBEINSIDE = stringSetting("MustBeInside", ""),
 		CANNOTBEINSIDE = stringSetting("CannotBeInside", ""),
-		REPLACESBO3 = stringSetting("ReplacesBO3", "")
+		REPLACESBO3 = stringSetting("ReplacesBO3", ""),
+	    FIXED_ROTATION = stringSetting("FixedRotation", "")
+
     ;
 
     // Enum settings

--- a/common/src/main/java/com/pg85/otg/customobjects/structures/bo4/CustomStructurePlotter.java
+++ b/common/src/main/java/com/pg85/otg/customobjects/structures/bo4/CustomStructurePlotter.java
@@ -461,6 +461,8 @@ public class CustomStructurePlotter
 			            			boolean canSpawnHere;
 
 				            		int scanDistance = 0;
+
+									Rotation fixedRotation = ((BO4)currentStructureSpawning[0]).getConfig().fixedRotation;
 				            		
 				            		if(!spawningStructureAtSpawn)
 				            		{
@@ -472,7 +474,14 @@ public class CustomStructurePlotter
 						            		{
 						            			// Find more free chunks until both height and width fit, just in case
 						            			// we can't fit length or width in the y direction.
-							            		if(right + left + 1 >= structureLength && right + left + 1 >= structureWidth)
+												if(
+														(fixedRotation == null && right + left + 1 >= structureWidth && right + left + 1 >= structureLength) ||
+																(
+																		(fixedRotation == Rotation.NORTH || fixedRotation == Rotation.SOUTH) && right + left + 1 >= structureWidth
+																) || (
+																(fixedRotation == Rotation.EAST || fixedRotation == Rotation.WEST) && right + left + 1 >= structureLength
+														)
+												)
 							            		{
 							            			rightEdgeFound = true; // leftEdgeFound is already true, since left and right will never spawn in the same pass.
 							            		}
@@ -562,8 +571,15 @@ public class CustomStructurePlotter
 						            		{
 						            			// Find more free chunks until both height and width fit, just in case
 						            			// we can't fit length or width in the y direction.
-							            		if(right + left + 1 >= structureLength && right + left + 1 >= structureWidth)
-							            		{
+												if(
+														(fixedRotation == null && right + left + 1 >= structureWidth && right + left + 1 >= structureLength) ||
+																(
+																		(fixedRotation == Rotation.NORTH || fixedRotation == Rotation.SOUTH) && right + left + 1 >= structureWidth
+																) || (
+																(fixedRotation == Rotation.EAST || fixedRotation == Rotation.WEST) && right + left + 1 >= structureLength
+														)
+												)
+												{
 							            			leftEdgeFound = true; // rightEdgeFound is already true, since left and right will never spawn in the same pass.
 							            		}
 						            		}
@@ -650,8 +666,15 @@ public class CustomStructurePlotter
 						            		if(!bottomEdgeFound)
 						            		{
 						            			// Find more free chunks until both height and width fit, just in case
-						            			// we can't fit length or width in the x direction.
-							            		if(bottom + top + 1 >= structureLength && bottom + top + 1 >= structureWidth)
+												// we can't fit length or width in the x direction.
+												if(
+														(fixedRotation == null && bottom + top + 1 >= structureWidth && bottom + top + 1 >= structureLength) ||
+																(
+																		(fixedRotation == Rotation.NORTH || fixedRotation == Rotation.SOUTH) && bottom + top + 1 >= structureLength
+																) || (
+																(fixedRotation == Rotation.EAST || fixedRotation == Rotation.WEST) && bottom + top + 1 >= structureWidth
+														)
+												)
 							            		{
 							            			bottomEdgeFound = true; // topEdgeFound is already true, since left and right will never spawn in the same pass.
 							            		}
@@ -741,7 +764,14 @@ public class CustomStructurePlotter
 						            		{
 						            			// Find more free chunks until both height and width fit, just in case
 						            			// we can't fit length or width in the x direction.
-							            		if(bottom + top + 1 >= structureLength && bottom + top + 1 >= structureWidth)
+												if(
+														(fixedRotation == null && bottom + top + 1 >= structureWidth && bottom + top + 1 >= structureLength) ||
+																(
+																		(fixedRotation == Rotation.NORTH || fixedRotation == Rotation.SOUTH) && bottom + top + 1 >= structureLength
+																) || (
+																(fixedRotation == Rotation.EAST || fixedRotation == Rotation.WEST) && bottom + top + 1 >= structureWidth
+														)
+												)
 							            		{
 							            			topEdgeFound = true; // bottomEdgeFound is already true, since left and right will never spawn in the same pass.
 							            		}
@@ -840,8 +870,8 @@ public class CustomStructurePlotter
 
 					            	// See if the structure will fit
 					            	if(
-				            			(structureLength <= areaLength && structureWidth <= areaWidth) ||
-				            			(structureLength <= areaWidth && structureWidth <= areaLength)
+											((fixedRotation == null || fixedRotation == Rotation.NORTH || fixedRotation == Rotation.SOUTH) && structureLength <= areaLength && structureWidth <= areaWidth) ||
+													((fixedRotation == null || fixedRotation == Rotation.EAST || fixedRotation == Rotation.WEST) && structureLength <= areaWidth && structureWidth <= areaLength)
 				        			)
 					            	{
 					            		// Determine the coordinates of the start BO4 and spawn the structure.
@@ -855,27 +885,31 @@ public class CustomStructurePlotter
 					            		// so we may have to try to spawn more structures afterwards.
 					            		
 					            		// Get rotated width/length and start chunk.
-					            		
-					            		boolean canSpawnUnrotated = false;
-					            		boolean canSpawnRotated = false;
-					            		if(structureLength <= areaLength && structureWidth <= areaWidth)
+
+										Rotation rotation = fixedRotation;
+										if(rotation == null)
 					            		{
-					            			canSpawnUnrotated = true;
-					            		}
-					            		if(structureLength <= areaWidth && structureWidth <= areaLength)
-					            		{
-					            			canSpawnRotated = true;	
-					            		}
-					            							            		
-					            		Rotation rotation = rand.nextBoolean() ? Rotation.NORTH : Rotation.SOUTH;
-					            		if(canSpawnUnrotated && canSpawnRotated)
-					            		{
-					            			rotation = Rotation.getRandomRotation(rand);
-					            		}
-					            		else if(canSpawnRotated)
-					            		{
-					            			rotation = rand.nextBoolean() ? Rotation.EAST : Rotation.WEST;
-					            		}
+											boolean canSpawnUnrotated = false;
+											boolean canSpawnRotated = false;
+											if(structureLength <= areaLength && structureWidth <= areaWidth)
+											{
+												canSpawnUnrotated = true;
+											}
+											if(structureLength <= areaWidth && structureWidth <= areaLength)
+											{
+												canSpawnRotated = true;
+											}
+
+											rotation = rand.nextBoolean() ? Rotation.NORTH : Rotation.SOUTH;
+											if(canSpawnUnrotated && canSpawnRotated)
+											{
+												rotation = Rotation.getRandomRotation(rand);
+											}
+											else if(canSpawnRotated)
+											{
+												rotation = rand.nextBoolean() ? Rotation.EAST : Rotation.WEST;
+											}
+										}
 					            		
 					            		int structureLengthRotated = 0;
 					            		int structureWidthRotated = 0;						            		

--- a/platforms/bukkit/src/main/java/com/pg85/otg/bukkit/generator/OTGChunkGenerator.java
+++ b/platforms/bukkit/src/main/java/com/pg85/otg/bukkit/generator/OTGChunkGenerator.java
@@ -66,7 +66,7 @@ public class OTGChunkGenerator extends ChunkGenerator
         // TODO: Add a setting to the worldconfig for the size of these caches. 
         // Worlds with lots of BO4's and large smoothing areas may want to increase this. 
         this.unloadedBlockColumnsCache = new FifoMap<BlockPos2D, LocalMaterialData[]>(1024);
-        this.unloadedChunksCache = new FifoMap<ChunkCoordinate, ChunkData>(128);
+        this.unloadedChunksCache = new FifoMap<ChunkCoordinate, ChunkData>(1024); //Changed 128 chunks cache to 1024 chunks cache for customstructures
     	lastUsedChunk1 = null;
     	lastUsedChunk2 = null;
     	lastUsedChunk3 = null;

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/generator/OTGChunkGenerator.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/generator/OTGChunkGenerator.java
@@ -77,7 +77,7 @@ public class OTGChunkGenerator implements IChunkGenerator
         // TODO: Add a setting to the worldconfig for the size of these caches. 
         // Worlds with lots of BO4's and large smoothing areas may want to increase this. 
         this.unloadedBlockColumnsCache = new FifoMap<BlockPos2D, LocalMaterialData[]>(1024);
-        this.unloadedChunksCache = new FifoMap<ChunkCoordinate, Chunk>(128);
+        this.unloadedChunksCache = new FifoMap<ChunkCoordinate, Chunk>(1024); //Changed 128 chunks cache to 1024 chunks cache for customstructures
     	lastUsedChunk1 = null;
     	lastUsedChunk2 = null;
     	lastUsedChunk3 = null;


### PR DESCRIPTION
- Increased Chunk Cache from 128 to 1024 chunks (bigger structures) & backported FixedRotation to 1.12.2
Use FixedRotation: NORTH/EAST/SOUTH/WEST in bo4's to fix their rotation.

Tested on both Spigot as Forge Clientside and Server environments.