### PR TITLE
1.12 otg+v9.5 r1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ defaultTasks 'clean', 'build', 'createReleaseJar', 'install'
 
 allprojects
 {
-    version = "1.12.2-v9.4"
+    version = "1.12.2-v9.6"
     group = "com.pg85.otg"
 
     // Version of the shadow plugin

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ defaultTasks 'clean', 'build', 'createReleaseJar', 'install'
 
 allprojects
 {
-    version = "1.12.2-v9.6"
+    version = "1.12.2-v9.5-R1"
     group = "com.pg85.otg"
 
     // Version of the shadow plugin

--- a/common/src/main/java/com/pg85/otg/configuration/standard/PluginStandardValues.java
+++ b/common/src/main/java/com/pg85/otg/configuration/standard/PluginStandardValues.java
@@ -31,6 +31,7 @@ public class PluginStandardValues extends Settings
     public static final Setting<Boolean> DEVELOPER_MODE = booleanSetting("DeveloperMode", false);
     public static final Setting<Integer> PREGENERATOR_MAX_CHUNKS_PER_TICK = intSetting("PregeneratorMaxChunksPerTick", 5, 1, 10);
 	public static final String MOD_ID = "openterraingenerator";
+	public static String GENERATOR_PRESET = "";
 
 	// TODO: This could be changed by other mods?
 	/**

--- a/platforms/bukkit/src/main/resources/plugin.yml
+++ b/platforms/bukkit/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: OpenTerrainGenerator
-version: 1.12.2-v9.4
+version: 1.12.2-v9.6
 description: 'Team OTG: PG85 (code), MC_Pitman & LordSmellyPants (graphics, web, community). Authvin, SuperCoder79 and Josh/Coll1234567 (more code). This mod is a fork of TerrainControl by Khorn/Wickth, Olof Cayorion Larsson, RutgerKok and Timethor. - OTG: Generate anything! -'
 authors: ['PeeGee85', 'Authvin', 'SuperCoder79', 'Josh/Coll1234567', 'RutgerKok', 'TimeThor', 'Khorn/Wickth', 'Olof Cayorion Larsson']
 main: com.pg85.otg.bukkit.OTGPlugin

--- a/platforms/bukkit/src/main/resources/plugin.yml
+++ b/platforms/bukkit/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: OpenTerrainGenerator
-version: 1.12.2-v9.6
+version: 1.12.2-v9.5-R1
 description: 'Team OTG: PG85 (code), MC_Pitman & LordSmellyPants (graphics, web, community). Authvin, SuperCoder79 and Josh/Coll1234567 (more code). This mod is a fork of TerrainControl by Khorn/Wickth, Olof Cayorion Larsson, RutgerKok and Timethor. - OTG: Generate anything! -'
 authors: ['PeeGee85', 'Authvin', 'SuperCoder79', 'Josh/Coll1234567', 'RutgerKok', 'TimeThor', 'Khorn/Wickth', 'Olof Cayorion Larsson']
 main: com.pg85.otg.bukkit.OTGPlugin

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/OTGPlugin.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/OTGPlugin.java
@@ -43,7 +43,7 @@ import net.minecraftforge.fml.common.network.FMLEventChannel;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = "openterraingenerator", name = "Open Terrain Generator", version = "v9.6", dependencies="required-after:otgcore@[1.12.2-v9.6]")
+@Mod(modid = "openterraingenerator", name = "Open Terrain Generator", version = "v9.5-R1", dependencies="required-after:otgcore@[1.12.2-v9.5-R1]")
 public class OTGPlugin
 {	
 	@SidedProxy(clientSide="com.pg85.otg.forge.network.client.ClientProxy", serverSide="com.pg85.otg.forge.network.server.ServerProxy")

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/OTGPlugin.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/OTGPlugin.java
@@ -43,7 +43,7 @@ import net.minecraftforge.fml.common.network.FMLEventChannel;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = "openterraingenerator", name = "Open Terrain Generator", version = "v9.4", dependencies="required-after:otgcore@[1.12.2-v9.4]")
+@Mod(modid = "openterraingenerator", name = "Open Terrain Generator", version = "v9.6", dependencies="required-after:otgcore@[1.12.2-v9.6]")
 public class OTGPlugin
 {	
 	@SidedProxy(clientSide="com.pg85.otg.forge.network.client.ClientProxy", serverSide="com.pg85.otg.forge.network.server.ServerProxy")

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/asm/excluded/launch/OTGASMModContainer.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/asm/excluded/launch/OTGASMModContainer.java
@@ -18,7 +18,7 @@ public class OTGASMModContainer extends DummyModContainer
 		meta.modId = "otgcore";
 		meta.name = "OTG Core";
 		meta.description = "Allows missing OTG biomes in the registry when a client connects to the server. OTG sends and registers the missing biomes on the client before the player joins the world. Also makes sure the correct biome is returned when querying the registry by id. Also allows gravity settings per world/dimension.";
-		meta.version = "1.12.2-v9.6";
+		meta.version = "1.12.2-v9.5-R1";
 		List<String> authorList = new ArrayList<String>();
 		authorList.add("PG85");
 		meta.authorList = authorList;

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/asm/excluded/launch/OTGASMModContainer.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/asm/excluded/launch/OTGASMModContainer.java
@@ -18,7 +18,7 @@ public class OTGASMModContainer extends DummyModContainer
 		meta.modId = "otgcore";
 		meta.name = "OTG Core";
 		meta.description = "Allows missing OTG biomes in the registry when a client connects to the server. OTG sends and registers the missing biomes on the client before the player joins the world. Also makes sure the correct biome is returned when querying the registry by id. Also allows gravity settings per world/dimension.";
-		meta.version = "1.12.2-v9.4";
+		meta.version = "1.12.2-v9.6";
 		List<String> authorList = new ArrayList<String>();
 		authorList.add("PG85");
 		meta.authorList = authorList;

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/dimensions/OTGWorldProvider.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/dimensions/OTGWorldProvider.java
@@ -11,6 +11,7 @@ import com.pg85.otg.configuration.world.WorldConfig;
 import com.pg85.otg.forge.ForgeEngine;
 import com.pg85.otg.forge.OTGPlugin;
 import com.pg85.otg.forge.world.ForgeWorld;
+import com.pg85.otg.logging.LogMarker;
 import com.pg85.otg.util.ChunkCoordinate;
 
 import net.minecraft.util.math.BlockPos;
@@ -178,7 +179,13 @@ public class OTGWorldProvider extends WorldProviderSurface
                 randZ = maxZ == 0 ? 0 : -maxZ + rand.nextInt(maxZ * 2);
             }
 
-			return new BlockPos(this.world.getWorldInfo().getSpawnX() + randX, this.world.getWorldInfo().getSpawnY(), this.world.getWorldInfo().getSpawnZ() + randZ);
+            int SpawnPosX = (this.world.getWorldInfo().getSpawnX() + randX);
+            int SpawnPosZ = (this.world.getWorldInfo().getSpawnZ() + randZ);
+
+            BlockPos SpawnPos = new BlockPos(SpawnPosX, 0, SpawnPosZ);
+            BlockPos SpawnPosNew = world.getTopSolidOrLiquidBlock(SpawnPos);
+
+			return new BlockPos(SpawnPosNew);
     	} else {
     		return super.getRandomizedSpawnPoint();
     	}

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/events/SaplingListener.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/events/SaplingListener.java
@@ -246,7 +246,11 @@ public class SaplingListener
                 && biomeConfig.replaceToBiomeName != null
                 && biomeConfig.replaceToBiomeName.trim().length() > 0)
         {
-           return world.getBiomeByNameOrNull(biomeConfig.replaceToBiomeName).getBiomeConfig();
+            LocalBiome localBiome = (world.getBiomeByNameOrNull(biomeConfig.replaceToBiomeName));
+            if (localBiome != null)
+            {
+               return localBiome.getBiomeConfig();
+            }
         }
         return null;
     }

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/world/OTGWorldType.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/world/OTGWorldType.java
@@ -1,6 +1,5 @@
 package com.pg85.otg.forge.world;
 
-import java.io.File;
 import com.pg85.otg.OTG;
 import com.pg85.otg.common.LocalWorld;
 import com.pg85.otg.configuration.dimensions.DimensionConfig;
@@ -18,13 +17,15 @@ import com.pg85.otg.forge.gui.GuiHandler;
 import com.pg85.otg.generator.biome.BiomeGenerator;
 import com.pg85.otg.logging.LogMarker;
 import com.pg85.otg.util.helpers.ReflectionHelper;
-
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.BiomeProvider;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.io.File;
+import static com.pg85.otg.configuration.standard.PluginStandardValues.GENERATOR_PRESET;
 
 public class OTGWorldType extends WorldType
 {
@@ -45,6 +46,7 @@ public class OTGWorldType extends WorldType
     {   	
         // Ignore client worlds, no need to know about OTG biomes and biome id's on the client.
     	// TODO: What about fog colors?
+
         if (mcWorld.isRemote)
         {
             return super.getBiomeProvider(mcWorld);
@@ -148,19 +150,27 @@ public class OTGWorldType extends WorldType
     	// For MP server
         if(!mcWorld.getMinecraftServer().isSinglePlayer())
         {
-	        WorldSettings worldSettings = new WorldSettings(mcWorld.getWorldInfo().getSeed(), mcWorld.getWorldInfo().getGameType(), mcWorld.getWorldInfo().isMapFeaturesEnabled(), mcWorld.getWorldInfo().isHardcoreModeEnabled(), OTGPlugin.OtgWorldType);
-	        worldSettings.setGeneratorOptions(PluginStandardValues.PLUGIN_NAME);
-	        mcWorld.getWorldInfo().setAllowCommands(mcWorld.getWorldInfo().areCommandsAllowed());
-	        mcWorld.getWorldInfo().populateFromWorldSettings(worldSettings);
+
+			if(mcWorld.getWorldInfo().getGeneratorOptions().length() > 0)
+			{
+				GENERATOR_PRESET = mcWorld.getWorldInfo().getGeneratorOptions();
+				OTG.log(LogMarker.INFO, "Server Properties Generator-Settings detected, initialize preset: " + mcWorld.getWorldInfo().getGeneratorOptions());
+			}
+
+			WorldSettings worldSettings = new WorldSettings(mcWorld.getWorldInfo().getSeed(), mcWorld.getWorldInfo().getGameType(), mcWorld.getWorldInfo().isMapFeaturesEnabled(), mcWorld.getWorldInfo().isHardcoreModeEnabled(), OTGPlugin.OtgWorldType);
+			worldSettings.setGeneratorOptions(PluginStandardValues.PLUGIN_NAME);
+			mcWorld.getWorldInfo().setAllowCommands(mcWorld.getWorldInfo().areCommandsAllowed());
+			mcWorld.getWorldInfo().populateFromWorldSettings(worldSettings);
+
     	}
         //
 
-        ForgeWorld world = ((ForgeEngine)OTG.getEngine()).getWorldLoader().getOrCreateForgeWorld(mcWorld);        
-        Class<? extends BiomeGenerator> biomeGenClass = world.getConfigs().getWorldConfig().biomeMode;
-        BiomeGenerator biomeGenerator = OTG.getBiomeModeManager().createCached(biomeGenClass, world);
-        BiomeProvider biomeProvider = this.createBiomeProvider(world, biomeGenerator);
-        world.setBiomeGenerator(biomeGenerator);
-        return biomeProvider;
+		ForgeWorld world = ((ForgeEngine)OTG.getEngine()).getWorldLoader().getOrCreateForgeWorld(mcWorld);
+		Class<? extends BiomeGenerator> biomeGenClass = world.getConfigs().getWorldConfig().biomeMode;
+		BiomeGenerator biomeGenerator = OTG.getBiomeModeManager().createCached(biomeGenClass, world);
+		BiomeProvider biomeProvider = this.createBiomeProvider(world, biomeGenerator);
+		world.setBiomeGenerator(biomeGenerator);
+		return biomeProvider;
     }
 
     /**

--- a/platforms/forge/src/main/java/com/pg85/otg/forge/world/WorldLoader.java
+++ b/platforms/forge/src/main/java/com/pg85/otg/forge/world/WorldLoader.java
@@ -5,8 +5,8 @@ import com.pg85.otg.common.LocalBiome;
 import com.pg85.otg.common.LocalWorld;
 import com.pg85.otg.configuration.biome.BiomeConfig;
 import com.pg85.otg.configuration.biome.BiomeConfigFinder;
-import com.pg85.otg.configuration.biome.BiomeLoadInstruction;
 import com.pg85.otg.configuration.biome.BiomeConfigFinder.BiomeConfigStub;
+import com.pg85.otg.configuration.biome.BiomeLoadInstruction;
 import com.pg85.otg.configuration.io.FileSettingsWriter;
 import com.pg85.otg.configuration.io.SettingsMap;
 import com.pg85.otg.configuration.standard.PluginStandardValues;
@@ -24,7 +24,6 @@ import com.pg85.otg.logging.LogMarker;
 import com.pg85.otg.network.ServerConfigProvider;
 import com.pg85.otg.util.helpers.FileHelper;
 import com.pg85.otg.util.minecraft.defaults.DefaultBiome;
-
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.DimensionType;
@@ -32,34 +31,30 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
-import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.BiomeDictionary.Type;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import javax.annotation.Nullable;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
-import javax.annotation.Nullable;
+import static com.pg85.otg.configuration.standard.PluginStandardValues.GENERATOR_PRESET;
+
 
 /**
  * Responsible for loading and unloading the world.
  *
  */
 public final class WorldLoader
-{	
+{
 	private final File configsDir;
     private final HashMap<String, ForgeWorld> worlds = new HashMap<String, ForgeWorld>();
     private final HashMap<String, ForgeWorld> unloadedWorlds = new HashMap<String, ForgeWorld>();
@@ -337,20 +332,27 @@ public final class WorldLoader
 
     @Nullable ForgeWorld getOrCreateForgeWorld(World mcWorld)
     {
-    	if(!mcWorld.getWorldInfo().getGeneratorOptions().equals(PluginStandardValues.PLUGIN_NAME))
-    	{
-    		throw new RuntimeException("Error: OTG tried to load a world that is missing OTG information. Was this world created via OTG? For Forge Single Player, be sure to use the OTG world creation screen.");
-    	}
+		if(!mcWorld.getWorldInfo().getGeneratorOptions().equals(PluginStandardValues.PLUGIN_NAME))
+		{
+			throw new RuntimeException("Error: OTG tried to load a world that is missing OTG information. Was this world created via OTG? For Forge Single Player, be sure to use the OTG world creation screen.");
+		}
 
+		String generatorOptions = GENERATOR_PRESET;
     	String worldName = WorldHelper.getName(mcWorld);
     	File worldConfigsFolder = null;
 
-    	worldConfigsFolder = this.getWorldDir(OTG.getDimensionsConfig().getDimensionConfig(worldName).PresetName);
-        if (worldConfigsFolder == null || !worldConfigsFolder.exists())
-        {
-            // OpenTerrainGenerator is not enabled for this world
-            return null;
-        }
+		if (!generatorOptions.trim().isEmpty()) {
+			// we have an actual string for preset name
+			worldConfigsFolder = this.getWorldDir(generatorOptions.trim());
+		} else {
+			worldConfigsFolder = this.getWorldDir(OTG.getDimensionsConfig().getDimensionConfig(worldName).PresetName);
+		}
+
+		if (worldConfigsFolder == null || !worldConfigsFolder.exists())
+		{
+			// OpenTerrainGenerator is not enabled for this world
+			return null;
+		}
 
         ForgeWorld world = this.getWorld(worldName);
         if (world == null)

--- a/platforms/forge/src/main/resources/mcmod.info
+++ b/platforms/forge/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
 	"name": "Open Terrain Generator",
 	"url": "https://www.openterraingenerator.com/",
 	"description": "Team OTG: PG85 (code), MC_Pitman & LordSmellyPants (graphics, web, community). Authvin, SuperCoder79 and Josh/Coll1234567 (more code). This mod is a fork of TerrainControl by Khorn/Wickth, Olof Cayorion Larsson, RutgerKok and Timethor. - OTG: Generate anything! -",
-	"version": "1.12.2-v9.4",
+	"version": "1.12.2-v9.6",
 	"credits" : "Team OTG",
 	"authors": [ "PeeGee85", "Authvin", "SuperCoder79", "Josh/Coll1234567", "RutgerKok", "TimeThor", "Khorn/Wickth", "Olof Cayorion Larsson"],
 	"mcversion": "1.12.2",

--- a/platforms/forge/src/main/resources/mcmod.info
+++ b/platforms/forge/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
 	"name": "Open Terrain Generator",
 	"url": "https://www.openterraingenerator.com/",
 	"description": "Team OTG: PG85 (code), MC_Pitman & LordSmellyPants (graphics, web, community). Authvin, SuperCoder79 and Josh/Coll1234567 (more code). This mod is a fork of TerrainControl by Khorn/Wickth, Olof Cayorion Larsson, RutgerKok and Timethor. - OTG: Generate anything! -",
-	"version": "1.12.2-v9.6",
+	"version": "1.12.2-v9.5-R1",
 	"credits" : "Team OTG",
 	"authors": [ "PeeGee85", "Authvin", "SuperCoder79", "Josh/Coll1234567", "RutgerKok", "TimeThor", "Khorn/Wickth", "Olof Cayorion Larsson"],
 	"mcversion": "1.12.2",


### PR DESCRIPTION
- Fixed nullpointer for SaplingListener causing a Crash at Sapling Grow Event when the biome returns null. 
- Fixed SpawnPointY, now spawning you in either liquid or air and not in stone.
- Generator-Settings= in server.properties can now be used to declare the preset. level-name= is not longer required but still works as a fallback.