### PR TITLE
[1.20.1] Fix trees spawning on water and ice

### DIFF
--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/CustomObject.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/CustomObject.java
@@ -4,6 +4,7 @@ import com.pg85.otg.customobject.structures.CustomStructureCache;
 import com.pg85.otg.interfaces.ICustomObject;
 import com.pg85.otg.interfaces.IWorldGenRegion;
 import com.pg85.otg.util.bo3.Rotation;
+import com.pg85.otg.util.materials.MaterialSet;
 
 import java.nio.file.Path;
 import java.util.Random;
@@ -60,6 +61,7 @@ public interface CustomObject extends SpawnableObject, ICustomObject {
 	 * @param world
 	 * @param x
 	 * @param z
+	 * @param sourceBlocks Blocks the tree may spawn on, or null for the default rules.
 	 * @return Whether the attempt was successful.
 	 */
     boolean spawnAsTree(
@@ -69,7 +71,8 @@ public interface CustomObject extends SpawnableObject, ICustomObject {
 			int x,
 			int z,
 			int minY,
-			int maxY
+			int maxY,
+			MaterialSet sourceBlocks
     );
 
     /**

--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/TreeObject.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/TreeObject.java
@@ -4,6 +4,8 @@ import com.pg85.otg.constants.Constants;
 import com.pg85.otg.customobject.structures.CustomStructureCache;
 import com.pg85.otg.interfaces.IWorldGenRegion;
 import com.pg85.otg.util.bo3.Rotation;
+import com.pg85.otg.util.materials.LocalMaterialData;
+import com.pg85.otg.util.materials.LocalMaterials;
 import com.pg85.otg.util.minecraft.TreeType;
 
 import java.nio.file.Path;
@@ -59,6 +61,9 @@ class TreeObject implements CustomObject {
         if (y < world.getWorldInfo().minY() || y > world.getWorldInfo().maxY()) {
             return false;
         }
+        if (!canSpawnAt(world, x, y, z)) {
+            return false;
+        }
         return spawnForced(
                 structureCache,
                 world,
@@ -69,6 +74,23 @@ class TreeObject implements CustomObject {
                 z,
                 false
         );
+    }
+
+    /**
+     * getHighestBlockAboveYAt also returns the first position above liquids,
+     * so without this check trees spawn on top of oceans, lakes and ice.
+     */
+    private boolean canSpawnAt(IWorldGenRegion world, int x, int y, int z) {
+        LocalMaterialData blockAtY = world.getMaterial(x, y, z);
+        if (blockAtY == null || !blockAtY.isAir()) {
+            return false;
+        }
+        LocalMaterialData blockBelow = world.getMaterial(x, y - 1, z);
+        return blockBelow != null
+                && !blockBelow.isLiquid()
+                && !blockBelow.isMaterial(LocalMaterials.ICE)
+                && !blockBelow.isMaterial(LocalMaterials.PACKED_ICE)
+                && !blockBelow.isMaterial(LocalMaterials.BLUE_ICE);
     }
 
     @Override
@@ -117,6 +139,10 @@ class TreeObject implements CustomObject {
         }
 
         if (y < world.getWorldInfo().minY() || y > world.getWorldInfo().maxY()) {
+            return false;
+        }
+
+        if (!canSpawnAt(world, x, y, z)) {
             return false;
         }
 

--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/TreeObject.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/TreeObject.java
@@ -6,6 +6,7 @@ import com.pg85.otg.interfaces.IWorldGenRegion;
 import com.pg85.otg.util.bo3.Rotation;
 import com.pg85.otg.util.materials.LocalMaterialData;
 import com.pg85.otg.util.materials.LocalMaterials;
+import com.pg85.otg.util.materials.MaterialSet;
 import com.pg85.otg.util.minecraft.TreeType;
 
 import java.nio.file.Path;
@@ -61,7 +62,7 @@ class TreeObject implements CustomObject {
         if (y < world.getWorldInfo().minY() || y > world.getWorldInfo().maxY()) {
             return false;
         }
-        if (!canSpawnAt(world, x, y, z)) {
+        if (!canSpawnAt(world, x, y, z, null)) {
             return false;
         }
         return spawnForced(
@@ -79,15 +80,22 @@ class TreeObject implements CustomObject {
     /**
      * getHighestBlockAboveYAt also returns the first position above liquids,
      * so without this check trees spawn on top of oceans, lakes and ice.
+     * When sourceBlocks is given, the block below must be in the set;
+     * otherwise anything solid except liquids and ice is accepted.
      */
-    private boolean canSpawnAt(IWorldGenRegion world, int x, int y, int z) {
+    private boolean canSpawnAt(IWorldGenRegion world, int x, int y, int z, MaterialSet sourceBlocks) {
         LocalMaterialData blockAtY = world.getMaterial(x, y, z);
         if (blockAtY == null || !blockAtY.isAir()) {
             return false;
         }
         LocalMaterialData blockBelow = world.getMaterial(x, y - 1, z);
-        return blockBelow != null
-                && !blockBelow.isLiquid()
+        if (blockBelow == null) {
+            return false;
+        }
+        if (sourceBlocks != null) {
+            return sourceBlocks.contains(blockBelow);
+        }
+        return !blockBelow.isLiquid()
                 && !blockBelow.isMaterial(LocalMaterials.ICE)
                 && !blockBelow.isMaterial(LocalMaterials.PACKED_ICE)
                 && !blockBelow.isMaterial(LocalMaterials.BLUE_ICE);
@@ -127,7 +135,8 @@ class TreeObject implements CustomObject {
             int x,
             int z,
             int minY,
-            int maxY
+            int maxY,
+            MaterialSet sourceBlocks
     ) {
         int y = world.getHighestBlockAboveYAt(x, z);
         Rotation rotation = Rotation.getRandomRotation(random);
@@ -142,7 +151,7 @@ class TreeObject implements CustomObject {
             return false;
         }
 
-        if (!canSpawnAt(world, x, y, z)) {
+        if (!canSpawnAt(world, x, y, z, sourceBlocks)) {
             return false;
         }
 

--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/bo2/BO2.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/bo2/BO2.java
@@ -359,8 +359,9 @@ public class BO2 extends CustomObjectConfigFile implements CustomObject
 
 	@Override
 	public boolean spawnAsTree(CustomStructureCache structureCache, IWorldGenRegion world,
-							   Random random, int x, int z, int minY, int maxY)
+							   Random random, int x, int z, int minY, int maxY, MaterialSet sourceBlocks)
 	{
+		// BO2s define their own source blocks in their config; the passed sourceBlocks is for TreeObject
 		return spawn(world, random, x, z, minY == -1 ? this.spawnElevationMin : minY, maxY == -1 ? this.spawnElevationMax : maxY);
 	} 
 	

--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/bo3/BO3.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/bo3/BO3.java
@@ -26,6 +26,7 @@ import com.pg85.otg.customobject.util.BO3Enums.OutsideSourceBlock;
 import com.pg85.otg.customobject.util.BO3Enums.SpawnHeightEnum;
 import com.pg85.otg.exceptions.InvalidConfigException;
 import com.pg85.otg.interfaces.IWorldGenRegion;
+import com.pg85.otg.util.materials.MaterialSet;
 import com.pg85.otg.util.ChunkCoordinate;
 import com.pg85.otg.util.biome.ReplaceBlockMatrix;
 import com.pg85.otg.util.bo3.Rotation;
@@ -288,7 +289,7 @@ public class BO3 implements StructuredCustomObject
 	// Used for trees during decoration
 	@Override
 	public boolean spawnAsTree(CustomStructureCache structureCache, IWorldGenRegion world,
-							   Random random, int x, int z, int minY, int maxY)
+							   Random random, int x, int z, int minY, int maxY, MaterialSet sourceBlocks)
 	{
 		// A bit ugly, but avoids having to create and implement another spawnAsTree method.
 		if(minY == -1)

--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/bo4/BO4.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/bo4/BO4.java
@@ -23,6 +23,7 @@ import com.pg85.otg.exceptions.InvalidConfigException;
 import com.pg85.otg.config.settings.biome.BiomeSettings;
 import com.pg85.otg.interfaces.IMaterialReader;
 import com.pg85.otg.interfaces.IWorldGenRegion;
+import com.pg85.otg.util.materials.MaterialSet;
 import com.pg85.otg.util.ChunkCoordinate;
 import com.pg85.otg.util.OTGLog;
 import com.pg85.otg.util.OTGMaterialReader;
@@ -149,8 +150,9 @@ public class BO4 implements StructuredCustomObject, BOPackSerializable
 	
 	@Override
 	public boolean spawnAsTree(CustomStructureCache structureCache, IWorldGenRegion world,
-							   Random random, int x, int z, int minY, int maxY)
+							   Random random, int x, int z, int minY, int maxY, MaterialSet sourceBlocks)
 	{
+		// BO4s cannot spawn as trees
 		return false;
 	}
 

--- a/common/common-customobject/src/main/java/com/pg85/otg/customobject/resource/TreeResource.java
+++ b/common/common-customobject/src/main/java/com/pg85/otg/customobject/resource/TreeResource.java
@@ -14,6 +14,7 @@ import com.pg85.otg.interfaces.IWorldGenRegion;
 import com.pg85.otg.util.OTGLog;
 import com.pg85.otg.util.logging.LogCategory;
 import com.pg85.otg.util.logging.LogLevel;
+import com.pg85.otg.util.materials.MaterialSet;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -29,8 +30,9 @@ public class TreeResource extends BiomeResourceBase implements ICustomObjectReso
 	private int[] treeObjectMinChances;
 	private int[] treeObjectMaxChances;
 	private boolean treesLoaded = false;
-	private final boolean useExtendedParams;	
+	private final boolean useExtendedParams;
 	private final int maxSpawn;
+	private final MaterialSet sourceBlocks;
 
 	public TreeResource(BiomeSettings biomeConfig, List<String> args) throws InvalidConfigException
 	{
@@ -58,11 +60,46 @@ public class TreeResource extends BiomeResourceBase implements ICustomObjectReso
 		this.useExtendedParams = useExtendedParams;
 		this.maxSpawn = maxSpawn;
 
-		for (int i = 1; i < args.size() - 1; i += 2)
+		// Tree definitions are (name, chance) pairs; anything after them is an
+		// optional list of materials the trees may spawn on
+		int treeDefEnd = findTreeDefinitionEnd(args);
+		for (int i = 1; i < treeDefEnd; i += 2)
 		{
 			this.treeNames.add(args.get(i));
 			this.treeChances.add(readInt(args.get(i + 1), 1, 100));
 		}
+
+		this.sourceBlocks = treeDefEnd < args.size() ? readMaterials(args, treeDefEnd) : null;
+	}
+
+	/**
+	 * Finds where the (treeName, chance) pairs end and source blocks begin.
+	 * A chance is an integer 1-100; the first pair that doesn't match marks
+	 * the start of the source block list.
+	 */
+	private int findTreeDefinitionEnd(List<String> args)
+	{
+		for (int i = 1; i < args.size(); i += 2)
+		{
+			if (i + 1 >= args.size())
+			{
+				// Odd trailing arg - must be source blocks
+				return i;
+			}
+			try
+			{
+				int chance = Integer.parseInt(args.get(i + 1).trim());
+				if (chance < 1 || chance > 100)
+				{
+					return i;
+				}
+			}
+			catch (NumberFormatException e)
+			{
+				return i;
+			}
+		}
+		return args.size();
 	}
 	
 	@Override
@@ -86,7 +123,7 @@ public class TreeResource extends BiomeResourceBase implements ICustomObjectReso
 					tree = this.treeObjects[treeNumber];
 					// Min/Max == -1 means use bo2/bo3 internal min/max height, otherwise use the optional min/max height defined with Tree()
 					if(tree != null && tree.spawnAsTree(structureCache, worldGenRegion,
-														random, x, z, this.treeObjectMinChances[treeNumber], this.treeObjectMaxChances[treeNumber]))
+														random, x, z, this.treeObjectMinChances[treeNumber], this.treeObjectMaxChances[treeNumber], this.sourceBlocks))
 					{
 						// Success!
 						spawned++;
@@ -176,6 +213,10 @@ public class TreeResource extends BiomeResourceBase implements ICustomObjectReso
 		for (int i = 0; i < this.treeNames.size(); i++)
 		{
 			output.append(",").append(this.treeNames.get(i)).append(",").append(this.treeChances.get(i));
+		}
+		if(this.sourceBlocks != null)
+		{
+			output.append(makeMaterials(this.sourceBlocks));
 		}
 		if(this.useExtendedParams)
 		{


### PR DESCRIPTION
## Problem

`Tree()` resources place trees directly on top of oceans, lakes and frozen surfaces. `getHighestBlockAboveYAt` returns the first position above the terrain *including liquids*, and neither tree spawn path (`TreeObject#process` from decoration, nor `TreeObject#spawnAsTree`) validated the surface before placing.

## Fix

Both paths now require air at the spawn position and a non-liquid, non-ice (`ice`/`packed_ice`/`blue_ice`) block below. One private helper, 26 added lines, no behavior change on land.

Deliberately minimal: no soil whitelist (some presets legitimately spawn trees on sand/terracotta), no new `Tree()` parameters — just stop placing trees on water.

## Testing

Manually tested in-game on MC 1.20.1 (Fabric Loader 0.19.3 + Fabric API 0.92.6+1.20.1): coastal and frozen-ocean areas no longer generate floating trees, land decoration unchanged.