### PR TITLE
[1.20.1] Worldgen stability fixes: carver crash, flooded caves, legacy preset compatibility

### DIFF
--- a/common/common-core/src/main/java/com/pg85/otg/gen/OTGChunkGenerator.java
+++ b/common/common-core/src/main/java/com/pg85/otg/gen/OTGChunkGenerator.java
@@ -249,7 +249,11 @@ public class OTGChunkGenerator implements ISurfaceGeneratorNoiseProvider {
             cacheX = x1 + largestRadius;
             for (int z1 = -smoothRadius; z1 <= smoothRadius; ++z1) {
                 cacheZ = z1 + largestRadius;
-                biome = biomes[cacheX * areaSize + cacheZ];
+                int biomeIndex = cacheX * areaSize + cacheZ;
+                if (biomeIndex >= biomes.length || (biome = biomes[biomeIndex]) == null) {
+                    // Provider can come up short at region edges; skip instead of crashing
+                    continue;
+                }
                 biomeTerrainSettings = biome.getTerrainSettings();
                 heightAt = biomeTerrainSettings.getBiomeHeight();
                 // TODO: vanilla reduces the weight by half when the depth here is greater than the center depth, but OTG doesn't do that?
@@ -277,7 +281,10 @@ public class OTGChunkGenerator implements ISurfaceGeneratorNoiseProvider {
             cacheX = x1 + largestRadius;
             for (int z1 = -chcSmoothRadius; z1 <= chcSmoothRadius; ++z1) {
                 cacheZ = z1 + largestRadius;
-                biome = biomes[cacheX * areaSize + cacheZ];
+                int chcBiomeIndex = cacheX * areaSize + cacheZ;
+                if (chcBiomeIndex >= biomes.length || (biome = biomes[chcBiomeIndex]) == null) {
+                    continue;
+                }
 
                 heightAt = biome.getTerrainSettings().getBiomeHeight();
                 weightAt = BIOME_WEIGHT_TABLE[x1 + 32 + (z1 + 32) * 65] / (heightAt + 2.0F);

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/carver/Carver.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/carver/Carver.java
@@ -135,7 +135,8 @@ public abstract class Carver {
                                     currentY,
                                     currentZ,
                                     foundSurface,
-                                    biomeConfig
+                                    biomeConfig,
+                                    otgWorldInfo
                             );
                         }
                     }
@@ -155,10 +156,13 @@ public abstract class Carver {
             int y,
             int relativeZ,
             MutableBoolean foundSurface,
-            BiomeSettings biomeConfig
+            BiomeSettings biomeConfig,
+            OTGWorldInfo otgWorldInfo
     ) {
         SurfaceSettings surface = biomeConfig.getSurfaceSettings();
-        int i = relativeX | relativeZ << 4 | y << 8;
+        // Offset Y by minY to ensure a non-negative BitSet index (1.18+ worlds can have negative Y)
+        int offsetY = y - otgWorldInfo.minY();
+        int i = relativeX | relativeZ << 4 | offsetY << 8;
         if (carvingMask.get(i)) {
             return false;
         }

--- a/common/common-generator/src/main/java/com/pg85/otg/gen/resource/DungeonResource.java
+++ b/common/common-generator/src/main/java/com/pg85/otg/gen/resource/DungeonResource.java
@@ -19,9 +19,12 @@ public class DungeonResource extends FrequencyResourceBase
         super(biomeConfig, args);
         assureSize(3, args);
 
+        // Legacy presets use Dungeon(Frequency,Rarity,MinAltitude,MaxAltitude);
+        // the current format drops Frequency (always 1). Accept both.
+        int offset = args.size() >= 4 ? 1 : 0;
         this.frequency = 1;
-        this.rarity = readRarity(args.get(0));
-        Pair<Integer, Integer> elevations = readElevations(args.get(1), args.get(2));
+        this.rarity = readRarity(args.get(offset));
+        Pair<Integer, Integer> elevations = readElevations(args.get(offset + 1), args.get(offset + 2));
 
         this.minAltitude = elevations.getFirst();
         this.maxAltitude = elevations.getSecond();

--- a/common/common-util/src/main/java/com/pg85/otg/config/settings/biome/BiomeSettings.java
+++ b/common/common-util/src/main/java/com/pg85/otg/config/settings/biome/BiomeSettings.java
@@ -73,7 +73,13 @@ public abstract class BiomeSettings implements ConfigFile {
 
     // Height / volatility
     public double getCHCData(int controlLayer) {
-        return this.getTerrainSettings().getCustomHeightControl().get(controlLayer);
+        var chc = this.getTerrainSettings().getCustomHeightControl();
+        if (controlLayer < 0 || controlLayer >= chc.size()) {
+            // Legacy presets carry CHC arrays sized for 256-high worlds; extended
+            // height worlds index past them. Treat missing layers as no control.
+            return 0.0;
+        }
+        return chc.get(controlLayer);
     }
 
     // OTG Custom structures (BO's)

--- a/platforms/fabric/src/main/java/com/pg85/otg/fabric/gen/FabricWorldGenRegion.java
+++ b/platforms/fabric/src/main/java/com/pg85/otg/fabric/gen/FabricWorldGenRegion.java
@@ -20,7 +20,6 @@ import com.pg85.otg.util.materials.LocalMaterialData;
 import com.pg85.otg.util.materials.LocalMaterials;
 import com.pg85.otg.util.minecraft.TreeType;
 import com.pg85.otg.util.nbt.NamedBinaryTag;
-import net.minecraft.ReportedException;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.features.CaveFeatures;
@@ -28,7 +27,7 @@ import net.minecraft.data.worldgen.features.EndFeatures;
 import net.minecraft.data.worldgen.features.TreeFeatures;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.IntTag;
-import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.monster.Guardian;
@@ -46,9 +45,6 @@ import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Optional;
 import java.util.Random;
@@ -513,26 +509,17 @@ public class FabricWorldGenRegion extends LocalWorldGenRegion {
             nbtTagCompound = new CompoundTag();
             if (entityData.getNameTagOrNBTFileName().toLowerCase().trim().endsWith(".txt")) {
                 try {
-                    var inputStream =
-                        new DataInputStream(new ByteArrayInputStream(entityData.getMetaData().getBytes()));
-                    nbtTagCompound = NbtIo.read(inputStream);
-                } catch (IOException | ReportedException e) {
-                    if (OTGLog.getLogger().getLogCategoryEnabled(LogCategory.CUSTOM_OBJECTS)) {
-                        OTGLog.log(
-                            LogLevel.ERROR,
-                            LogCategory.CUSTOM_OBJECTS,
-                            "Could not parse nbt for Entity() "
-                            + entityData.makeString()
-                            + ", file: "
-                            + entityData.getNameTagOrNBTFileName()
-                        );
-                    }
-                    throw new RuntimeException(
-                        "Could not parse nbt for Entity() "
-                        + entityData.makeString()
-                        + ", file: "
-                        + entityData.getNameTagOrNBTFileName(), e
+                    // .txt files contain text NBT (SNBT), not the binary format
+                    nbtTagCompound = TagParser.parseTag(entityData.getMetaData());
+                } catch (Exception e) {
+                    // A broken preset file shouldn't kill chunk generation — skip the entity
+                    OTGLog.getLogger().error(LogCategory.CUSTOM_OBJECTS,
+                        "Could not parse nbt for Entity() %s, file: %s, error: %s",
+                        entityData.makeString(),
+                        entityData.getNameTagOrNBTFileName(),
+                        e.getMessage()
                     );
+                    return;
                 }
                 // Specify which type of entity to spawn
                 nbtTagCompound.putString("id", entityData.getResourceLocation());

--- a/platforms/fabric/src/main/java/com/pg85/otg/fabric/gen/noise/OTGNoiseRouterFactory.java
+++ b/platforms/fabric/src/main/java/com/pg85/otg/fabric/gen/noise/OTGNoiseRouterFactory.java
@@ -39,7 +39,9 @@ import net.minecraft.world.level.levelgen.synth.NormalNoise;
  *   cave threshold depth; caves are carved out of solid terrain only.
  * - No slideOverworld: OTG's pipeline already fades the top of the world, and vanilla's slide
  *   anchors are hardcoded to -64..320, which mis-anchors on configurable world heights.
- * - Aquifers and ore veins disabled; fluid placement comes from {@link OTGFluidPicker}.
+ * - Ore veins disabled. Aquifers run with vanilla noises on top of {@link OTGFluidPicker}
+ *   as the global picker: open terrain floods to the per-biome water level, while caves
+ *   below it stay dry apart from vanilla-style aquifer pockets.
  * - Climate/biome slots are zero; OTG does its own biome placement.
  */
 public final class OTGNoiseRouterFactory {
@@ -73,11 +75,15 @@ public final class OTGNoiseRouterFactory {
         DensityFunction depthProxy = new OTGDepthProxyFunction(internalGenerator, depthGradient);
         DensityFunction finalDensity = finalDensity(otgTerrain, depthProxy, functions, noises);
 
+        // Vanilla aquifer noises (NoiseRouterData.overworld, 1.20.1). With aquifers enabled,
+        // the aquifer keeps caves below the water level dry apart from local pockets;
+        // OTGFluidPicker stays the global picker, so per-biome water levels still apply
+        // to open terrain (oceans, lakes).
         NoiseRouter router = new NoiseRouter(
-                DensityFunctions.zero(), // barrierNoise
-                DensityFunctions.zero(), // fluidLevelFloodednessNoise
-                DensityFunctions.zero(), // fluidLevelSpreadNoise
-                DensityFunctions.zero(), // lavaNoise
+                DensityFunctions.noise(noises.getOrThrow(Noises.AQUIFER_BARRIER), 0.5), // barrierNoise
+                DensityFunctions.noise(noises.getOrThrow(Noises.AQUIFER_FLUID_LEVEL_FLOODEDNESS), 0.67), // fluidLevelFloodednessNoise
+                DensityFunctions.noise(noises.getOrThrow(Noises.AQUIFER_FLUID_LEVEL_SPREAD), 0.7142857142857143), // fluidLevelSpreadNoise
+                DensityFunctions.noise(noises.getOrThrow(Noises.AQUIFER_LAVA)), // lavaNoise
                 DensityFunctions.zero(), // temperature
                 DensityFunctions.zero(), // vegetation
                 DensityFunctions.zero(), // continents
@@ -100,7 +106,7 @@ public final class OTGNoiseRouterFactory {
                 registeredSettings.spawnTarget(),
                 registeredSettings.seaLevel(),
                 registeredSettings.disableMobGeneration(),
-                false, // aquifersEnabled: NoiseChunk uses Aquifer.createDisabled(fluidPicker)
+                true,  // aquifersEnabled: without them every cave below the water level floods
                 false, // oreVeinsEnabled: vein router slots are zero
                 registeredSettings.useLegacyRandomSource()
         );


### PR DESCRIPTION
## What this fixes

Five independent worldgen issues, one commit each:

1. **Carver crash below y=0 on extended-height worlds** — the carving mask index used the raw block Y (`relativeX | relativeZ << 4 | y << 8`), which goes negative with MinY below zero and crashes `BitSet` with `IndexOutOfBoundsException` as soon as a cave or ravine carves under y=0. The Y is now offset by the world minimum, the same way the ravine height cache a few lines above already does.

2. **Legacy 4-argument `Dungeon()` format** — old presets use `Dungeon(Frequency,Rarity,MinAltitude,MaxAltitude)`; the current 3-argument parser silently misreads them, shifting rarity/altitudes by one. Both forms are accepted now (frequency is fixed to 1 either way).

3. **`Entity()` `.txt` NBT files crashed chunk generation** — these files contain text NBT (the old mojangson format), but the code fed them to the binary `NbtIo` reader, which throws `EOFException` on any such file — and the handler rethrew it as `RuntimeException`, killing the whole chunk. Reproducible with Biome Bundle's `Ruins/Generic/Cleric.txt`. `.txt` is now parsed with `TagParser` (SNBT), and a broken file logs an error and skips the entity instead of taking the world down.

4. **Out-of-range guards in biome smoothing and CHC lookups** — legacy presets carry `CustomHeightControl` lists sized for 256-high worlds; on extended-height worlds the CHC smoothing indexes past them and crashes. Missing layers are now treated as no height control, and the biome-array lookups in both smoothing loops are bounds/null-checked so a short region from the biome provider degrades to a skipped sample instead of a crash.

5. **Everything below the water level was one big flooded cave system** — with aquifers disabled, `NoiseChunk` uses `Aquifer.createDisabled(fluidPicker)` and every carved or noise-cave block below the biome water level becomes water. The vanilla aquifer noises (values from `NoiseRouterData.overworld`, 1.20.1) are now wired into the router's aquifer slots and aquifers are enabled in the runtime settings. `OTGFluidPicker` remains the global picker, so open terrain (oceans, lakes) still floods to the per-biome water level, while caves below it stay dry apart from vanilla-style aquifer pockets and deep lava.

## Testing

Manually tested in-game on MC 1.20.1 (Forge 47.4.21, NeoForge 47.1.106, Fabric Loader 0.19.3 + Fabric API 0.92.6+1.20.1): caves below sea level generate dry with occasional aquifer pockets, Biome Bundle no longer crashes on entity ruins, and cave/ravine carving below y=0 no longer crashes. Also smoke-tested as a fabric dev dedicated server (fresh world, `level-type=otg:default_preset`, no log errors).